### PR TITLE
feat: add --upload to flows and mcp scan commands

### DIFF
--- a/src/cli/commands/flows.ts
+++ b/src/cli/commands/flows.ts
@@ -15,11 +15,13 @@ export const flowsCommand = new Command('flows')
   .option('--json', 'Output as JSON')
   .option('-o, --output <file>', 'Write output to file')
   .option('--config <file>', 'Path to config file (default: .g0.yaml)')
+  .option('--upload', 'Upload results to Guard0 platform')
   .option('--no-banner', 'Suppress the g0 banner')
   .action(async (targetPath: string, options: {
     json?: boolean;
     output?: string;
     config?: string;
+    upload?: boolean;
     banner?: boolean;
   }) => {
     let resolvedPath: string;
@@ -79,6 +81,29 @@ export const flowsCommand = new Command('flows')
         if (options.output) {
           reportFlowsJson(result, options.output);
           console.log(`JSON flow analysis also written to: ${options.output}`);
+        }
+      }
+      // Upload to platform
+      const { shouldUpload } = await import('../../platform/upload.js');
+      const uploadDecision = await shouldUpload(options.upload);
+      if (uploadDecision.upload) {
+        try {
+          if (uploadDecision.isAuto) {
+            console.log('\n  Auto-uploading (authenticated)...');
+          }
+          const { uploadResults, collectProjectMeta, collectMachineMeta, detectCIMeta } = await import('../../platform/upload.js');
+          const response = await uploadResults({
+            type: 'flows',
+            project: collectProjectMeta(resolvedPath),
+            machine: collectMachineMeta(),
+            ci: detectCIMeta(),
+            result,
+          });
+          if (response) {
+            console.log(`\n  Uploaded to: ${response.url}`);
+          }
+        } catch (err) {
+          console.error(`  Upload failed: ${err instanceof Error ? err.message : err}`);
         }
       }
     } catch (error) {

--- a/src/cli/commands/mcp.ts
+++ b/src/cli/commands/mcp.ts
@@ -254,10 +254,12 @@ const scanSubcommand = new Command('scan')
   .argument('<path>', 'Path to MCP server source or config file')
   .option('--json', 'Output as JSON')
   .option('-o, --output <file>', 'Write output to file')
+  .option('--upload', 'Upload results to Guard0 platform')
   .option('--no-banner', 'Suppress the g0 banner')
-  .action((targetPath: string, options: {
+  .action(async (targetPath: string, options: {
     json?: boolean;
     output?: string;
+    upload?: boolean;
     banner?: boolean;
   }) => {
     const resolvedPath = path.resolve(targetPath);
@@ -290,6 +292,30 @@ const scanSubcommand = new Command('scan')
         reportMCPTerminal(result);
         if (options.output) {
           reportMCPJson(result, options.output);
+        }
+      }
+
+      // Upload to platform
+      const { shouldUpload } = await import('../../platform/upload.js');
+      const uploadDecision = await shouldUpload(options.upload);
+      if (uploadDecision.upload) {
+        try {
+          if (uploadDecision.isAuto) {
+            console.log('\n  Auto-uploading (authenticated)...');
+          }
+          const { uploadResults, collectProjectMeta, collectMachineMeta, detectCIMeta } = await import('../../platform/upload.js');
+          const response = await uploadResults({
+            type: 'mcp',
+            project: collectProjectMeta(resolvedPath),
+            machine: collectMachineMeta(),
+            ci: detectCIMeta(),
+            result,
+          });
+          if (response) {
+            console.log(`\n  Uploaded to: ${response.url}`);
+          }
+        } catch (err) {
+          console.error(`  Upload failed: ${err instanceof Error ? err.message : err}`);
         }
       }
     } catch (error) {

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -4,6 +4,7 @@ import type { ScanResult } from '../types/score.js';
 import type { InventoryResult } from '../types/inventory.js';
 import type { MCPScanResult } from '../types/mcp-scan.js';
 import type { TestRunResult } from '../types/test.js';
+import type { FlowAnalysisResult } from '../types/flow.js';
 
 // ─── Auth ────────────────────────────────────────────────────────────────────
 
@@ -60,11 +61,20 @@ export interface TestUploadPayload {
   result: TestRunResult;
 }
 
+export interface FlowsUploadPayload {
+  type: 'flows';
+  project: ProjectMeta;
+  machine: MachineMeta;
+  ci?: CIMeta;
+  result: FlowAnalysisResult;
+}
+
 export type UploadPayload =
   | ScanUploadPayload
   | InventoryUploadPayload
   | MCPUploadPayload
-  | TestUploadPayload;
+  | TestUploadPayload
+  | FlowsUploadPayload;
 
 export interface UploadResponse {
   id: string;


### PR DESCRIPTION
## Summary
- Add `--upload` support to `g0 flows` command with `FlowsUploadPayload` type
- Add `--upload` support to `g0 mcp scan` subcommand (was missing — only the parent `g0 mcp` command had it)
- Both auto-upload when authenticated, matching existing `scan`/`inventory` behavior

## Test plan
- [ ] Run `g0 flows . --upload` and verify upload succeeds
- [ ] Run `g0 mcp scan <path> --upload` and verify upload succeeds
- [ ] Run both without `--upload` while authenticated — verify auto-upload
- [ ] Run `npx vitest run` — all 832 tests pass