### PR TITLE
chore: release v1.3.0 — version bump and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,13 +310,29 @@ Python · TypeScript · JavaScript · Java · Go
 
 </td>
 </tr>
+<tr>
+<td>
+
+**Advanced Analysis**
+
+Pipeline Taint Tracking · Cross-Tool Correlation · Cross-File Exfiltration · Analyzability Scoring · Description-Behavior Alignment · AI Meta-Analysis
+
+</td>
+<td>
+
+**Configurable Policies**
+
+3 Presets (strict/balanced/permissive) · Severity Overrides · Domain Weights · Threshold Tuning · Per-Analyzer Toggles
+
+</td>
+</tr>
 </table>
 
 <table>
 <tr>
-<td align="center"><strong>1,214+</strong><br><sub>Security Rules</sub></td>
+<td align="center"><strong>1,118+</strong><br><sub>Security Rules</sub></td>
 <td align="center"><strong>4,020+</strong><br><sub>Attack Payloads</sub></td>
-<td align="center"><strong>21</strong><br><sub>Attack Categories</sub></td>
+<td align="center"><strong>25</strong><br><sub>Attack Categories</sub></td>
 <td align="center"><strong>5</strong><br><sub>Adaptive Strategies</sub></td>
 </tr>
 <tr>
@@ -531,7 +547,7 @@ Terminal (default), JSON, SARIF 2.1.0, HTML, CycloneDX 1.6, and Markdown.
 |----------|-------------|
 | [Getting Started](docs/getting-started.md) | Installation, first scan, reading output |
 | [Architecture](docs/architecture.md) | Pipeline overview, module map, data flow |
-| [Rules Reference](docs/rules.md) | All 1,214+ rules — domains, severities, check types |
+| [Rules Reference](docs/rules.md) | All 1,118+ rules — domains, severities, check types |
 | [Custom Rules](docs/custom-rules.md) | YAML rule schema, all 11 check types, examples |
 | [Framework Guide](docs/frameworks.md) | Per-framework detection, patterns, and findings |
 | [Understanding Findings](docs/findings.md) | Finding anatomy, filtering, suppression, triage |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,7 +92,7 @@ The analysis engine runs all rules against the Agent Graph and source code. Rule
 
 ### YAML Rules (`src/rules/builtin/`)
 
-715+ declarative rules compiled at startup by `src/rules/yaml-compiler.ts`. Support 11 check types:
+675+ declarative rules compiled at startup by `src/rules/yaml-compiler.ts`. Support 11 check types:
 
 | Check Type | What It Does |
 |-----------|-------------|
@@ -107,6 +107,28 @@ The analysis engine runs all rules against the Agent Graph and source code. Rule
 | `project_missing` | Project lacks a security control |
 | `taint_flow` | Data flows from source to sink without sanitizer |
 | `no_check` | Advisory-only, no static check |
+
+### Advanced Analyzers
+
+Beyond rule-based detection, g0 runs specialized analyzers in the pipeline:
+
+| Analyzer | Module | What It Does |
+|----------|--------|-------------|
+| **Pipeline Taint** | `src/analyzers/pipeline-taint.ts` | Detects multi-step shell exfil chains (source → obfuscation → sink) in subprocess calls |
+| **Cross-Tool Correlation** | `src/analyzers/cross-tool-correlation.ts` | Identifies 7 dangerous capability combinations across agent-bound tools |
+| **Cross-File Exfiltration** | `src/analyzers/cross-file-exfil.ts` | Traces sensitive reads → import chain → network writes via moduleGraph |
+| **Analyzability Scoring** | `src/analyzers/analyzability.ts` | Fail-closed scoring — measures what % of codebase was actually inspectable |
+| **Description Alignment** | `src/mcp/description-alignment.ts` | Compares MCP tool descriptions vs actual code capabilities |
+| **Manifest Consistency** | `src/mcp/manifest-checker.ts` | Detects undeclared/phantom tools between source and config |
+
+These analyzers can be toggled via `.g0.yaml`:
+
+```yaml
+analyzers:
+  pipeline_taint: true
+  cross_file: true
+  analyzability: true
+```
 
 ### False Positive Reduction
 

--- a/docs/dynamic-testing.md
+++ b/docs/dynamic-testing.md
@@ -27,10 +27,10 @@ flowchart LR
 | Metric | Count |
 |--------|-------|
 | Attack payloads | 4,020+ |
-| Attack categories | 21 (including `openclaw-attacks`) |
+| Attack categories | 25 (including `openclaw-attacks` and scan-driven categories) |
 | Harmful subcategories | 26 |
 | Payload mutators | 20 (with stacking) |
-| Heuristic signals | 29+ |
+| Heuristic signals | 32+ |
 | Multi-turn strategies | 3 static + 5 adaptive |
 | Adaptive strategies | 5 |
 | Judge levels | 4 |
@@ -96,7 +96,7 @@ g0 test --target http://localhost:3000/api/chat --system-prompt-file ./prompts/s
 
 ## Attack Categories
 
-g0 includes 21 categories of adversarial payloads totaling 4,020+:
+g0 includes 25 categories of adversarial payloads totaling 4,020+:
 
 | Category | Payloads | What It Tests |
 |----------|----------|--------------|
@@ -121,6 +121,10 @@ g0 includes 21 categories of adversarial payloads totaling 4,020+:
 | `compliance` | 15 | Regulatory compliance violations, policy boundary testing |
 | `domain-specific` | 6 | Industry-specific adversarial scenarios |
 | `openclaw-attacks` | 20 | SKILL.md/SOUL.md/MEMORY.md attacks, ClawHavoc IOC testing, CVE-2026-28363/CVE-2026-25253 probes, multi-skill chains |
+| `cross-tool-chain` | dynamic | Multi-turn payloads exploiting dangerous tool combinations (e.g., file-read → network-send). Generated from static scan cross-tool correlation findings |
+| `taint-exploit` | dynamic | Payloads derived from pipeline taint analysis — tests if agents execute detected exfil chains (e.g., `cat /etc/passwd \| base64 \| curl`) |
+| `description-mismatch` | dynamic | Probes tools for capabilities contradicting their description (e.g., "read-only" tool with write access) |
+| `tool-output-injection` | dynamic | Tests if tool output can inject instructions into subsequent agent reasoning across tool boundaries |
 
 ### Harmful Content Subcategories
 
@@ -144,6 +148,24 @@ g0 test --target http://localhost:3000/api/chat --payloads PI-001,PI-002,JB-001
 
 # Run specific OpenClaw payloads by ID
 g0 test --target http://localhost:3000/api/chat --payloads OC-003,OC-004,OC-005
+```
+
+### Scan-Driven Dynamic Testing
+
+When using `--auto`, g0 leverages static scan findings to generate smarter, targeted attack payloads. Four categories are generated dynamically based on what the scanner discovered:
+
+| Signal Source | Payload Category | What It Generates |
+|--------------|------------------|-------------------|
+| Cross-tool correlation | `cross-tool-chain` | Multi-turn payloads chaining dangerous tool combos (e.g., "read credentials with tool A, send to external server with tool B") |
+| Pipeline taint tracking | `taint-exploit` | Payloads that attempt the exact exfil chains found in source code (direct + indirect step-by-step) |
+| Description-behavior alignment | `description-mismatch` | Probes that test undisclosed capabilities (e.g., tool claims read-only but code has shell access) |
+| Tool output analysis | `tool-output-injection` | Tests if data returned by one tool can inject instructions into agent reasoning for the next tool |
+
+These payloads score higher in targeting when their corresponding scan signals are present (+3 to +4 boost). If analyzability is below 70%, all payloads get a +1 boost since static analysis alone can't be trusted.
+
+```bash
+# Auto mode uses scan findings to generate targeted payloads
+g0 test --target http://localhost:3000/api/chat --auto .
 ```
 
 ## Curated Datasets

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -114,15 +114,23 @@ Enable AI analysis for deeper insights:
 
 ```bash
 g0 scan . --ai
+
+# Consensus mode — run FP detection N times, keep only majority-agreed decisions
+g0 scan . --ai --ai-consensus 3
 ```
 
 Requires one of: `ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or `GOOGLE_API_KEY`.
+
+The AI pass includes a meta-analyzer that reviews all findings holistically, considering taint flows, cross-file chains, and analyzability gaps to reduce false positives.
 
 ## Configuration
 
 Create a `.g0.yaml` in your project root to customize behavior:
 
 ```yaml
+# Use a preset as a starting point
+preset: strict  # strict | balanced | permissive
+
 min_score: 70
 rules_dir: ./rules
 exclude_rules:
@@ -130,6 +138,43 @@ exclude_rules:
 exclude_paths:
   - tests/
   - node_modules/
+
+# Override severity for specific rules
+severity_overrides:
+  AA-DL-001: critical
+  AA-TS-050: low
+
+# Tune finding thresholds
+thresholds:
+  max_findings_per_rule: 50
+  low_severity_cap: 10
+  medium_severity_cap: 30
+
+# Enable/disable specific analyzers
+analyzers:
+  taint_flow: true
+  cross_file: true
+  pipeline_taint: true
+  analyzability: true
+
+# Adjust domain weights for scoring
+domain_weights:
+  data-leakage: 1.5
+  tool-safety: 1.2
+```
+
+### Presets
+
+Presets provide sensible defaults you can override:
+
+| Preset | Description |
+|--------|-------------|
+| `strict` | High-signal only — critical+high findings, fail_on: medium, min_score: 80 |
+| `balanced` | Default behavior — all severities, standard thresholds |
+| `permissive` | Critical only — relaxed thresholds, optional analyzers disabled |
+
+```bash
+g0 scan . --preset strict
 ```
 
 ## Next Steps

--- a/docs/mcp-security.md
+++ b/docs/mcp-security.md
@@ -42,6 +42,35 @@ g0 mcp --json                    # JSON output
 g0 mcp --json -o mcp-report.json # JSON to file
 ```
 
+## Multi-Language Source Scanning
+
+When scanning MCP server source code, g0 extracts tool declarations across three languages:
+
+| Language | Patterns Detected |
+|----------|------------------|
+| **Python** | `@server.tool()`, `server.add_tool()`, FastMCP patterns |
+| **TypeScript/JavaScript** | `server.tool("name", ...)`, `createTool({ name })`, `new Tool(...)` |
+| **Go** | `mcp.NewTool("name", ...)`, `server.AddTool(...)` |
+
+For each extracted tool, g0 detects capabilities (filesystem, network, shell, database, code-execution, email) and checks for input validation and sandboxing.
+
+### Description-Behavior Alignment
+
+g0 compares what a tool's description claims vs what its code actually does:
+
+- A tool described as "read-only" that has write or shell capabilities
+- A tool claiming "no network access" that makes HTTP calls
+- Overprivileged descriptions using language like "any file", "full access", "all permissions"
+
+Mismatches generate findings with severity based on the undisclosed capability (shell/code-execution = high).
+
+### Manifest Consistency
+
+g0 compares tools found in MCP source code against tools declared in MCP configuration:
+
+- **Undeclared tools** — present in code but not in config (shadow tools)
+- **Phantom tools** — declared in config but not found in code (stale/suspicious entries)
+
 ## MCP Server Discovery
 
 When scanning local configs, g0 discovers:

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,13 +1,13 @@
 # g0 Security Rules Reference
 
-g0 ships **1,214 security rules** across **12 security domains**, combining 543 TypeScript-based rules with 671 YAML declarative rules.
+g0 ships **1,218 security rules** across **12 security domains**, combining 543 TypeScript-based rules with 675 YAML declarative rules.
 
 ## By the Numbers
 
 | Domain | TS Rules | YAML Rules | Total |
 |--------|:--------:|:----------:|:-----:|
 | Goal Integrity | 60 | 60 | **120** |
-| Tool Safety | 40 | 108 | **148** |
+| Tool Safety | 40 | 112 | **152** |
 | Identity & Access | 66 | 44 | **110** |
 | Supply Chain | 33 | 61 | **94** |
 | Code Execution | 60 | 32 | **92** |
@@ -19,9 +19,9 @@ g0 ships **1,214 security rules** across **12 security domains**, combining 543 
 | Reliability Bounds | 40 | 45 | **85** |
 | Rogue Agent | 30 | 44 | **74** |
 | Enrichment | 15 | — | **15** |
-| **Total** | **543** | **671** | **1,214** |
+| **Total** | **543** | **675** | **1,218** |
 
-> **New in this release:** 10 OpenClaw rules — AA-SC-121..125 (ClawHavoc IOC, safeBins bypass CVE-2026-28363, RCE CVE-2026-25253) and AA-DL-133..137 (credential/PII detection in MEMORY.md and openclaw.json). See [OpenClaw Security](openclaw-security.md).
+> **New in v1.3.0:** 4 tool-safety rules — AA-TS-181 (excessive dangerous capabilities), AA-TS-182 (excessive unvalidated params), AA-TS-183 (overprivileged description language), AA-TS-184 (MCP server with >15 tools).
 
 ## Rule Architecture
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guard0/g0",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "The control layer for AI agents — discover, assess, and govern your agent infrastructure",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Bump package version from 1.2.0 to 1.3.0
- Document all new features introduced in #69 (enhanced scanning architecture)

### Documentation updates

- **getting-started.md** — Expanded `.g0.yaml` config with presets, severity overrides, thresholds, analyzers, domain weights; `--ai-consensus` docs
- **dynamic-testing.md** — 21→25 attack categories, 4 new scan-driven categories, scan-driven testing section
- **mcp-security.md** — Multi-language source scanning (Python/TS/JS/Go), description-behavior alignment, manifest consistency
- **architecture.md** — Advanced analyzers table (pipeline taint, cross-tool, cross-file, analyzability, description alignment, manifest checker)
- **rules.md** — Updated counts to 1,218 (675 YAML + 543 TS), new AA-TS-181..184
- **README.md** — Updated metrics, added Advanced Analysis + Configurable Policies to features table

## Test plan

- [x] Docs render correctly on GitHub
- [x] Version in package.json is 1.3.0
- [x] After merge, create GitHub Release `v1.3.0` to trigger npm publish