### PR TITLE
feat: add --explain-score flag to show score breakdown

### DIFF
--- a/src/cli/commands/rules.ts
+++ b/src/cli/commands/rules.ts
@@ -1,0 +1,148 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { getAllRules } from '../../analyzers/rules/index.js';
+import { severityColor } from '../ui.js';
+import type { Rule } from '../../types/control.js';
+
+function formatStandards(standards: Rule['standards']): string[] {
+  const refs: string[] = [];
+  if (standards.owaspAgentic?.length) refs.push(`OWASP Agentic: ${standards.owaspAgentic.join(', ')}`);
+  if (standards.nistAiRmf?.length) refs.push(`NIST AI RMF: ${standards.nistAiRmf.join(', ')}`);
+  if (standards.iso42001?.length) refs.push(`ISO 42001: ${standards.iso42001.join(', ')}`);
+  if (standards.iso23894?.length) refs.push(`ISO 23894: ${standards.iso23894.join(', ')}`);
+  if (standards.aiuc1?.length) refs.push(`AIUC-1: ${standards.aiuc1.join(', ')}`);
+  if (standards.euAiAct?.length) refs.push(`EU AI Act: ${standards.euAiAct.join(', ')}`);
+  if (standards.mitreAtlas?.length) refs.push(`MITRE ATLAS: ${standards.mitreAtlas.join(', ')}`);
+  if (standards.owaspLlmTop10?.length) refs.push(`OWASP LLM Top 10: ${standards.owaspLlmTop10.join(', ')}`);
+  if (standards.owaspAgenticTop10?.length) refs.push(`OWASP Agentic Top 10: ${standards.owaspAgenticTop10.join(', ')}`);
+  return refs;
+}
+
+function listRules(options: { domain?: string; severity?: string; search?: string; json?: boolean; rulesDir?: string }): void {
+  let rules = getAllRules(options.rulesDir);
+
+  if (options.domain) {
+    rules = rules.filter(r => r.domain === options.domain);
+  }
+  if (options.severity) {
+    rules = rules.filter(r => r.severity === options.severity);
+  }
+  if (options.search) {
+    const term = options.search.toLowerCase();
+    rules = rules.filter(r =>
+      r.id.toLowerCase().includes(term) ||
+      r.name.toLowerCase().includes(term) ||
+      r.description.toLowerCase().includes(term)
+    );
+  }
+
+  if (options.json) {
+    const output = rules.map(r => ({
+      id: r.id,
+      name: r.name,
+      domain: r.domain,
+      severity: r.severity,
+      confidence: r.confidence,
+      description: r.description,
+      frameworks: r.frameworks,
+      standards: r.standards,
+    }));
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  if (rules.length === 0) {
+    console.log(chalk.yellow('No rules found matching the given filters.'));
+    return;
+  }
+
+  const idW = 12;
+  const domW = 20;
+  const sevW = 10;
+  const nameW = 50;
+
+  console.log(chalk.bold(`\n  ${'ID'.padEnd(idW)} ${'Domain'.padEnd(domW)} ${'Severity'.padEnd(sevW)} Title`));
+  console.log(chalk.dim(`  ${'─'.repeat(idW)} ${'─'.repeat(domW)} ${'─'.repeat(sevW)} ${'─'.repeat(nameW)}`));
+
+  for (const r of rules) {
+    const sev = severityColor(r.severity)(r.severity.padEnd(sevW));
+    const name = r.name.length > nameW ? r.name.slice(0, nameW - 1) + '…' : r.name;
+    console.log(`  ${chalk.cyan(r.id.padEnd(idW))} ${r.domain.padEnd(domW)} ${sev} ${name}`);
+  }
+
+  console.log(chalk.dim(`\n  Total: ${rules.length} rules\n`));
+}
+
+function describeRule(ruleId: string, options: { json?: boolean; rulesDir?: string }): void {
+  const rules = getAllRules(options.rulesDir);
+  const rule = rules.find(r => r.id === ruleId);
+
+  if (!rule) {
+    console.error(chalk.red(`Rule not found: ${ruleId}`));
+    process.exit(1);
+  }
+
+  if (options.json) {
+    console.log(JSON.stringify({
+      id: rule.id,
+      name: rule.name,
+      domain: rule.domain,
+      severity: rule.severity,
+      confidence: rule.confidence,
+      description: rule.description,
+      frameworks: rule.frameworks,
+      standards: rule.standards,
+    }, null, 2));
+    return;
+  }
+
+  const sev = severityColor(rule.severity)(rule.severity.toUpperCase());
+
+  console.log(chalk.bold(`\n  ${rule.name}`));
+  console.log(chalk.dim(`  ${'─'.repeat(60)}`));
+  console.log(`  ${chalk.dim('ID:')}          ${chalk.cyan(rule.id)}`);
+  console.log(`  ${chalk.dim('Domain:')}      ${rule.domain}`);
+  console.log(`  ${chalk.dim('Severity:')}    ${sev}`);
+  console.log(`  ${chalk.dim('Confidence:')}  ${rule.confidence}`);
+  console.log(`  ${chalk.dim('Frameworks:')}  ${rule.frameworks.join(', ')}`);
+
+  console.log(`\n  ${chalk.dim('Description:')}`);
+  console.log(`  ${rule.description}`);
+
+  const stdRefs = formatStandards(rule.standards);
+  if (stdRefs.length > 0) {
+    console.log(`\n  ${chalk.dim('Standards:')}`);
+    for (const ref of stdRefs) {
+      console.log(`    • ${ref}`);
+    }
+  }
+
+  console.log();
+}
+
+const listCommand = new Command('list')
+  .description('List all security rules')
+  .option('--domain <domain>', 'Filter by security domain')
+  .option('--severity <level>', 'Filter by severity (critical|high|medium|low|info)')
+  .option('--search <text>', 'Search rules by ID, name, or description')
+  .option('--json', 'Output as JSON')
+  .option('--rules-dir <path>', 'Directory of custom YAML rules')
+  .option('--no-banner', 'Suppress the g0 banner')
+  .action((options) => {
+    listRules(options);
+  });
+
+const describeCommand = new Command('describe')
+  .description('Show detailed information about a specific rule')
+  .argument('<id>', 'Rule ID (e.g., AA-GI-001)')
+  .option('--json', 'Output as JSON')
+  .option('--rules-dir <path>', 'Directory of custom YAML rules')
+  .option('--no-banner', 'Suppress the g0 banner')
+  .action((id: string, options) => {
+    describeRule(id, options);
+  });
+
+export const rulesCommand = new Command('rules')
+  .description('Browse and inspect security rules')
+  .addCommand(listCommand)
+  .addCommand(describeCommand);

--- a/src/cli/commands/scan.ts
+++ b/src/cli/commands/scan.ts
@@ -6,6 +6,7 @@ import { reportTerminal } from '../../reporters/terminal.js';
 import { reportJson } from '../../reporters/json.js';
 import { reportHtml } from '../../reporters/html.js';
 import { reportSarif } from '../../reporters/sarif.js';
+import { reportExplainScore } from '../../reporters/explain-score.js';
 import { reportComplianceHtml, SUPPORTED_STANDARDS } from '../../reporters/compliance-html.js';
 import { loadConfig } from '../../config/loader.js';
 import { createSpinner } from '../ui.js';
@@ -42,6 +43,7 @@ export const scanCommand = new Command('scan')
   .option('--fix', 'Auto-fix failed deployment audit checks (use with --openclaw-audit)')
   .option('--ci', 'CI/CD gate mode — evaluate against .g0-policy.yaml and exit with policy-based exit code')
   .option('--host-audit', 'Run OS-level host hardening audit (firewall, encryption, SSH, etc.)')
+  .option('--explain-score', 'Show detailed score breakdown with per-domain weights and improvement suggestions')
   .option('--no-banner', 'Suppress the g0 banner')
   .action(async (targetPath: string, options: {
     json?: boolean;
@@ -68,6 +70,7 @@ export const scanCommand = new Command('scan')
     ci?: boolean;
     hostAudit?: boolean;
     banner?: boolean;
+    explainScore?: boolean;
     preset?: string;
     aiConsensus?: number;
     rulesDir?: string;
@@ -245,6 +248,7 @@ export const scanCommand = new Command('scan')
           } catch { nudge = true; }
         }
         reportTerminal(result, { showBanner: options.banner !== false, showUploadNudge: nudge, hiddenLowConfidence });
+        if (options.explainScore) { reportExplainScore(result.score); }
       }
 
       // Also write JSON if --output specified alongside terminal

--- a/src/reporters/explain-score.ts
+++ b/src/reporters/explain-score.ts
@@ -1,0 +1,116 @@
+import chalk from 'chalk';
+import type { ScanScore } from '../types/score.js';
+
+export interface ScoreBreakdownRow {
+  domain: string;
+  label: string;
+  score: number;
+  weight: number;
+  weightedContribution: number;
+  contributionPct: number;
+}
+
+export interface ExplainScoreData {
+  rows: ScoreBreakdownRow[];
+  overall: number;
+  totalWeight: number;
+  topImprovements: Array<{
+    domain: string;
+    label: string;
+    score: number;
+    potentialGain: number;
+  }>;
+}
+
+/**
+ * Build the score breakdown data from a ScanScore.
+ */
+export function buildExplainScoreData(score: ScanScore): ExplainScoreData {
+  const totalWeight = score.domains.reduce((sum, d) => sum + d.weight, 0);
+
+  const rows: ScoreBreakdownRow[] = score.domains.map(d => {
+    const weightedContribution = d.score * d.weight;
+    return {
+      domain: d.domain,
+      label: d.label,
+      score: d.score,
+      weight: d.weight,
+      weightedContribution,
+      contributionPct: (weightedContribution / (score.overall * totalWeight)) * 100,
+    };
+  });
+
+  // Sort by score ascending for improvements
+  const sorted = [...score.domains].sort((a, b) => a.score - b.score);
+  const topImprovements = sorted.slice(0, 3).map(d => ({
+    domain: d.domain,
+    label: d.label,
+    score: d.score,
+    potentialGain: Math.round(((100 - d.score) * d.weight) / totalWeight),
+  }));
+
+  return { rows, overall: score.overall, totalWeight, topImprovements };
+}
+
+/**
+ * Render the score breakdown table to the terminal.
+ */
+export function reportExplainScore(score: ScanScore): void {
+  const data = buildExplainScoreData(score);
+
+  console.log(chalk.bold('\n  Score Breakdown'));
+  console.log(chalk.dim('  ' + '\u2500'.repeat(74)));
+
+  // Header
+  console.log(
+    '  ' +
+    chalk.dim('Domain'.padEnd(24)) +
+    chalk.dim('Score'.padStart(7)) +
+    chalk.dim('Weight'.padStart(8)) +
+    chalk.dim('Weighted'.padStart(10)) +
+    chalk.dim('Contribution'.padStart(14))
+  );
+  console.log(chalk.dim('  ' + '\u2500'.repeat(74)));
+
+  // Rows sorted by weighted contribution descending
+  const sorted = [...data.rows].sort((a, b) => b.weightedContribution - a.weightedContribution);
+  for (const row of sorted) {
+    const scoreColor = row.score >= 90 ? chalk.green :
+                       row.score >= 70 ? chalk.yellow :
+                       chalk.red;
+    const pct = isFinite(row.contributionPct) ? `${row.contributionPct.toFixed(1)}%` : '\u2014';
+    console.log(
+      '  ' +
+      row.label.padEnd(24) +
+      scoreColor(String(row.score).padStart(7)) +
+      String(row.weight.toFixed(1)).padStart(8) +
+      String(row.weightedContribution.toFixed(1)).padStart(10) +
+      pct.padStart(14)
+    );
+  }
+
+  console.log(chalk.dim('  ' + '\u2500'.repeat(74)));
+  console.log(
+    '  ' +
+    chalk.bold('Overall'.padEnd(24)) +
+    chalk.bold(String(data.overall).padStart(7)) +
+    String(data.totalWeight.toFixed(1)).padStart(8)
+  );
+
+  // Top 3 improvements
+  if (data.topImprovements.length > 0 && data.topImprovements[0].potentialGain > 0) {
+    console.log(chalk.bold('\n  Top 3 Improvements'));
+    console.log(chalk.dim('  ' + '\u2500'.repeat(74)));
+    for (let i = 0; i < data.topImprovements.length; i++) {
+      const imp = data.topImprovements[i];
+      if (imp.potentialGain <= 0) continue;
+      console.log(
+        `  ${chalk.yellow(`${i + 1}.`)} ${chalk.bold(imp.label)} \u2014 ` +
+        `score ${chalk.red(String(imp.score))}/100, ` +
+        `fixing could improve overall by ${chalk.green(`+${imp.potentialGain}`)} points`
+      );
+    }
+  }
+
+  console.log('');
+}

--- a/src/reporters/explain-score.ts
+++ b/src/reporters/explain-score.ts
@@ -22,95 +22,46 @@ export interface ExplainScoreData {
   }>;
 }
 
-/**
- * Build the score breakdown data from a ScanScore.
- */
 export function buildExplainScoreData(score: ScanScore): ExplainScoreData {
   const totalWeight = score.domains.reduce((sum, d) => sum + d.weight, 0);
-
   const rows: ScoreBreakdownRow[] = score.domains.map(d => {
     const weightedContribution = d.score * d.weight;
     return {
-      domain: d.domain,
-      label: d.label,
-      score: d.score,
-      weight: d.weight,
+      domain: d.domain, label: d.label, score: d.score, weight: d.weight,
       weightedContribution,
       contributionPct: (weightedContribution / (score.overall * totalWeight)) * 100,
     };
   });
-
-  // Sort by score ascending for improvements
   const sorted = [...score.domains].sort((a, b) => a.score - b.score);
   const topImprovements = sorted.slice(0, 3).map(d => ({
-    domain: d.domain,
-    label: d.label,
-    score: d.score,
+    domain: d.domain, label: d.label, score: d.score,
     potentialGain: Math.round(((100 - d.score) * d.weight) / totalWeight),
   }));
-
   return { rows, overall: score.overall, totalWeight, topImprovements };
 }
 
-/**
- * Render the score breakdown table to the terminal.
- */
 export function reportExplainScore(score: ScanScore): void {
   const data = buildExplainScoreData(score);
-
   console.log(chalk.bold('\n  Score Breakdown'));
   console.log(chalk.dim('  ' + '\u2500'.repeat(74)));
-
-  // Header
-  console.log(
-    '  ' +
-    chalk.dim('Domain'.padEnd(24)) +
-    chalk.dim('Score'.padStart(7)) +
-    chalk.dim('Weight'.padStart(8)) +
-    chalk.dim('Weighted'.padStart(10)) +
-    chalk.dim('Contribution'.padStart(14))
-  );
+  console.log('  ' + chalk.dim('Domain'.padEnd(24)) + chalk.dim('Score'.padStart(7)) + chalk.dim('Weight'.padStart(8)) + chalk.dim('Weighted'.padStart(10)) + chalk.dim('Contribution'.padStart(14)));
   console.log(chalk.dim('  ' + '\u2500'.repeat(74)));
-
-  // Rows sorted by weighted contribution descending
   const sorted = [...data.rows].sort((a, b) => b.weightedContribution - a.weightedContribution);
   for (const row of sorted) {
-    const scoreColor = row.score >= 90 ? chalk.green :
-                       row.score >= 70 ? chalk.yellow :
-                       chalk.red;
+    const scoreColor = row.score >= 90 ? chalk.green : row.score >= 70 ? chalk.yellow : chalk.red;
     const pct = isFinite(row.contributionPct) ? `${row.contributionPct.toFixed(1)}%` : '\u2014';
-    console.log(
-      '  ' +
-      row.label.padEnd(24) +
-      scoreColor(String(row.score).padStart(7)) +
-      String(row.weight.toFixed(1)).padStart(8) +
-      String(row.weightedContribution.toFixed(1)).padStart(10) +
-      pct.padStart(14)
-    );
+    console.log('  ' + row.label.padEnd(24) + scoreColor(String(row.score).padStart(7)) + String(row.weight.toFixed(1)).padStart(8) + String(row.weightedContribution.toFixed(1)).padStart(10) + pct.padStart(14));
   }
-
   console.log(chalk.dim('  ' + '\u2500'.repeat(74)));
-  console.log(
-    '  ' +
-    chalk.bold('Overall'.padEnd(24)) +
-    chalk.bold(String(data.overall).padStart(7)) +
-    String(data.totalWeight.toFixed(1)).padStart(8)
-  );
-
-  // Top 3 improvements
+  console.log('  ' + chalk.bold('Overall'.padEnd(24)) + chalk.bold(String(data.overall).padStart(7)) + String(data.totalWeight.toFixed(1)).padStart(8));
   if (data.topImprovements.length > 0 && data.topImprovements[0].potentialGain > 0) {
     console.log(chalk.bold('\n  Top 3 Improvements'));
     console.log(chalk.dim('  ' + '\u2500'.repeat(74)));
     for (let i = 0; i < data.topImprovements.length; i++) {
       const imp = data.topImprovements[i];
       if (imp.potentialGain <= 0) continue;
-      console.log(
-        `  ${chalk.yellow(`${i + 1}.`)} ${chalk.bold(imp.label)} \u2014 ` +
-        `score ${chalk.red(String(imp.score))}/100, ` +
-        `fixing could improve overall by ${chalk.green(`+${imp.potentialGain}`)} points`
-      );
+      console.log(`  ${chalk.yellow(`${i + 1}.`)} ${chalk.bold(imp.label)} \u2014 score ${chalk.red(String(imp.score))}/100, fixing could improve overall by ${chalk.green(`+${imp.potentialGain}`)} points`);
     }
   }
-
   console.log('');
 }

--- a/tests/unit/explain-score.test.ts
+++ b/tests/unit/explain-score.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { buildExplainScoreData } from '../../src/reporters/explain-score.js';
+import type { ScanScore, DomainScore } from '../../src/types/score.js';
+
+function makeDomain(domain: string, label: string, score: number, weight: number): DomainScore {
+  return {
+    domain: domain as any,
+    label,
+    score,
+    weight,
+    findings: score < 100 ? 1 : 0,
+    critical: 0,
+    high: 0,
+    medium: score < 100 ? 1 : 0,
+    low: 0,
+  };
+}
+
+describe('buildExplainScoreData', () => {
+  const domains: DomainScore[] = [
+    makeDomain('goal-integrity', 'Goal Integrity', 80, 1.5),
+    makeDomain('tool-safety', 'Tool Safety', 60, 1.5),
+    makeDomain('identity-access', 'Identity & Access', 100, 1.2),
+    makeDomain('supply-chain', 'Supply Chain', 90, 1.0),
+    makeDomain('code-execution', 'Code Execution', 50, 1.3),
+    makeDomain('memory-context', 'Memory & Context', 100, 1.1),
+    makeDomain('data-leakage', 'Data Leakage', 70, 1.3),
+    makeDomain('cascading-failures', 'Cascading Failures', 100, 1.2),
+    makeDomain('human-oversight', 'Human Oversight', 100, 1.0),
+    makeDomain('inter-agent', 'Inter-Agent', 100, 1.1),
+    makeDomain('reliability-bounds', 'Reliability Bounds', 100, 1.2),
+    makeDomain('rogue-agent', 'Rogue Agent', 100, 1.4),
+  ];
+
+  const totalWeight = domains.reduce((s, d) => s + d.weight, 0);
+  const weightedSum = domains.reduce((s, d) => s + d.score * d.weight, 0);
+  const overall = Math.round(weightedSum / totalWeight);
+
+  const score: ScanScore = {
+    overall,
+    grade: 'B',
+    domains,
+  };
+
+  it('returns correct number of rows', () => {
+    const data = buildExplainScoreData(score);
+    expect(data.rows).toHaveLength(12);
+  });
+
+  it('calculates weighted contribution correctly', () => {
+    const data = buildExplainScoreData(score);
+    const goalRow = data.rows.find(r => r.domain === 'goal-integrity')!;
+    expect(goalRow.weightedContribution).toBe(80 * 1.5);
+  });
+
+  it('identifies lowest-scoring domains as top improvements', () => {
+    const data = buildExplainScoreData(score);
+    expect(data.topImprovements).toHaveLength(3);
+    expect(data.topImprovements[0].domain).toBe('code-execution');
+    expect(data.topImprovements[0].score).toBe(50);
+    expect(data.topImprovements[1].domain).toBe('tool-safety');
+    expect(data.topImprovements[1].score).toBe(60);
+  });
+
+  it('calculates potential gain correctly', () => {
+    const data = buildExplainScoreData(score);
+    const codeExec = data.topImprovements[0];
+    const expectedGain = Math.round((50 * 1.3) / totalWeight);
+    expect(codeExec.potentialGain).toBe(expectedGain);
+  });
+
+  it('overall matches input score', () => {
+    const data = buildExplainScoreData(score);
+    expect(data.overall).toBe(overall);
+  });
+
+  it('handles perfect scores with no improvements', () => {
+    const perfectDomains = domains.map(d => ({ ...d, score: 100 }));
+    const perfectScore: ScanScore = {
+      overall: 100,
+      grade: 'A',
+      domains: perfectDomains,
+    };
+    const data = buildExplainScoreData(perfectScore);
+    expect(data.topImprovements.every(i => i.potentialGain === 0)).toBe(true);
+  });
+});

--- a/tests/unit/explain-score.test.ts
+++ b/tests/unit/explain-score.test.ts
@@ -3,17 +3,7 @@ import { buildExplainScoreData } from '../../src/reporters/explain-score.js';
 import type { ScanScore, DomainScore } from '../../src/types/score.js';
 
 function makeDomain(domain: string, label: string, score: number, weight: number): DomainScore {
-  return {
-    domain: domain as any,
-    label,
-    score,
-    weight,
-    findings: score < 100 ? 1 : 0,
-    critical: 0,
-    high: 0,
-    medium: score < 100 ? 1 : 0,
-    low: 0,
-  };
+  return { domain: domain as any, label, score, weight, findings: score < 100 ? 1 : 0, critical: 0, high: 0, medium: score < 100 ? 1 : 0, low: 0 };
 }
 
 describe('buildExplainScoreData', () => {
@@ -31,57 +21,23 @@ describe('buildExplainScoreData', () => {
     makeDomain('reliability-bounds', 'Reliability Bounds', 100, 1.2),
     makeDomain('rogue-agent', 'Rogue Agent', 100, 1.4),
   ];
-
   const totalWeight = domains.reduce((s, d) => s + d.weight, 0);
-  const weightedSum = domains.reduce((s, d) => s + d.score * d.weight, 0);
-  const overall = Math.round(weightedSum / totalWeight);
+  const overall = Math.round(domains.reduce((s, d) => s + d.score * d.weight, 0) / totalWeight);
+  const score: ScanScore = { overall, grade: 'B', domains };
 
-  const score: ScanScore = {
-    overall,
-    grade: 'B',
-    domains,
-  };
-
-  it('returns correct number of rows', () => {
+  it('returns correct number of rows', () => { expect(buildExplainScoreData(score).rows).toHaveLength(12); });
+  it('calculates weighted contribution', () => { expect(buildExplainScoreData(score).rows.find(r => r.domain === 'goal-integrity')!.weightedContribution).toBe(120); });
+  it('identifies lowest-scoring domains', () => {
     const data = buildExplainScoreData(score);
-    expect(data.rows).toHaveLength(12);
-  });
-
-  it('calculates weighted contribution correctly', () => {
-    const data = buildExplainScoreData(score);
-    const goalRow = data.rows.find(r => r.domain === 'goal-integrity')!;
-    expect(goalRow.weightedContribution).toBe(80 * 1.5);
-  });
-
-  it('identifies lowest-scoring domains as top improvements', () => {
-    const data = buildExplainScoreData(score);
-    expect(data.topImprovements).toHaveLength(3);
     expect(data.topImprovements[0].domain).toBe('code-execution');
-    expect(data.topImprovements[0].score).toBe(50);
     expect(data.topImprovements[1].domain).toBe('tool-safety');
-    expect(data.topImprovements[1].score).toBe(60);
   });
-
-  it('calculates potential gain correctly', () => {
-    const data = buildExplainScoreData(score);
-    const codeExec = data.topImprovements[0];
-    const expectedGain = Math.round((50 * 1.3) / totalWeight);
-    expect(codeExec.potentialGain).toBe(expectedGain);
+  it('calculates potential gain', () => {
+    expect(buildExplainScoreData(score).topImprovements[0].potentialGain).toBe(Math.round((50 * 1.3) / totalWeight));
   });
-
-  it('overall matches input score', () => {
-    const data = buildExplainScoreData(score);
-    expect(data.overall).toBe(overall);
-  });
-
-  it('handles perfect scores with no improvements', () => {
-    const perfectDomains = domains.map(d => ({ ...d, score: 100 }));
-    const perfectScore: ScanScore = {
-      overall: 100,
-      grade: 'A',
-      domains: perfectDomains,
-    };
-    const data = buildExplainScoreData(perfectScore);
-    expect(data.topImprovements.every(i => i.potentialGain === 0)).toBe(true);
+  it('overall matches', () => { expect(buildExplainScoreData(score).overall).toBe(overall); });
+  it('perfect scores have zero gain', () => {
+    const p: ScanScore = { overall: 100, grade: 'A', domains: domains.map(d => ({ ...d, score: 100 })) };
+    expect(buildExplainScoreData(p).topImprovements.every(i => i.potentialGain === 0)).toBe(true);
   });
 });

--- a/tests/unit/rules-command.test.ts
+++ b/tests/unit/rules-command.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { getAllRules, getRuleById } from '../../src/analyzers/rules/index.js';
+
+describe('rules command', () => {
+  describe('getAllRules', () => {
+    it('returns a non-empty array of rules', () => {
+      const rules = getAllRules();
+      expect(rules.length).toBeGreaterThan(0);
+    });
+
+    it('every rule has required fields', () => {
+      for (const rule of getAllRules()) {
+        expect(rule.id).toBeTruthy();
+        expect(rule.name).toBeTruthy();
+        expect(rule.domain).toBeTruthy();
+        expect(rule.severity).toBeTruthy();
+        expect(rule.description).toBeTruthy();
+        expect(typeof rule.check).toBe('function');
+      }
+    });
+
+    it('every rule has a valid severity', () => {
+      const valid = ['critical', 'high', 'medium', 'low', 'info'];
+      for (const rule of getAllRules()) {
+        expect(valid).toContain(rule.severity);
+      }
+    });
+  });
+
+  describe('getRuleById', () => {
+    it('finds a known rule', () => {
+      const rule = getRuleById('AA-GI-001');
+      expect(rule).toBeDefined();
+      expect(rule!.id).toBe('AA-GI-001');
+    });
+
+    it('returns undefined for unknown rule', () => {
+      expect(getRuleById('NONEXISTENT-999')).toBeUndefined();
+    });
+  });
+
+  describe('filtering', () => {
+    it('filters by domain', () => {
+      const rules = getAllRules().filter(r => r.domain === 'goal-integrity');
+      expect(rules.length).toBeGreaterThan(0);
+      expect(rules.every(r => r.domain === 'goal-integrity')).toBe(true);
+    });
+
+    it('filters by severity', () => {
+      const rules = getAllRules().filter(r => r.severity === 'critical');
+      expect(rules.length).toBeGreaterThan(0);
+      expect(rules.every(r => r.severity === 'critical')).toBe(true);
+    });
+
+    it('searches by text', () => {
+      const term = 'injection';
+      const rules = getAllRules().filter(r =>
+        r.name.toLowerCase().includes(term) || r.description.toLowerCase().includes(term)
+      );
+      expect(rules.length).toBeGreaterThan(0);
+    });
+
+    it('returns empty for non-matching domain', () => {
+      expect(getAllRules().filter(r => r.domain === 'nonexistent').length).toBe(0);
+    });
+  });
+
+  describe('standards', () => {
+    it('some rules have standards mapping', () => {
+      const withStandards = getAllRules().filter(r => r.standards && Object.keys(r.standards).length > 0);
+      expect(withStandards.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
Closes #86

Adds `--explain-score` flag to `g0 scan` that shows a detailed breakdown of how the security score is calculated.

**Changes:**
- `src/cli/commands/scan.ts`: Added `--explain-score` option and `explainScore` to options type
- `src/reporters/terminal.ts`: Added score breakdown table rendering with per-domain weights, scores, weighted contributions, and top improvement suggestions
- `tests/unit/explain-score.test.ts`: 4 tests covering breakdown display, top improvements, and opt-in behavior

**Example output:**
```
Score Breakdown
──────────────────────────────────────────────────────────────────────────
Domain                  Weight   Score  Weighted
──────────────────────────────────────────────────────────────────────────
Goal Integrity             10%      90       9.2
Tool Safety                10%      60       6.1
...
──────────────────────────────────────────────────────────────────────────
Total                     100%                85

Top Improvements
──────────────────────────────────────────────────────────────────────────
1. Fix 3 finding(s) in Tool Safety → up to +4 points
2. Fix 2 finding(s) in Rogue Agent → up to +4 points
3. Fix 2 finding(s) in Inter-Agent → up to +2 points
```