### PR TITLE
fix: forward plugin security events to Slack webhook

### DIFF
--- a/src/daemon/runner.ts
+++ b/src/daemon/runner.ts
@@ -107,9 +107,23 @@ async function main(): Promise<void> {
       logFile: config.eventReceiver.logFile,
       logger,
       onEvent: (event) => {
-        // Log high-severity events as warnings
-        if (event.type.includes('injection') || event.type.includes('blocked')) {
+        // Log and alert on high-severity plugin security events
+        const isSecurityEvent = event.type.includes('injection') || event.type.includes('blocked') || event.type.includes('pii');
+        if (isSecurityEvent) {
           logger.warn(`Security event: ${event.source}/${event.type}`);
+          if (config.alerting?.webhookUrl) {
+            const severity = event.type.includes('injection') || event.type.includes('blocked') ? 'critical' : 'high';
+            const detail = event.data
+              ? Object.entries(event.data)
+                  .filter(([k]) => k !== 'phase')
+                  .map(([k, v]) => `${k}: ${typeof v === 'object' ? JSON.stringify(v) : v}`)
+                  .join(', ')
+              : 'No details';
+            import('./alerter.js').then(({ sendUrgentAlert }) =>
+              sendUrgentAlert(config.alerting!, `Plugin: ${event.type}`,
+                `Agent: ${event.agentId ?? 'unknown'}, ${detail}`, severity as 'critical' | 'high')
+            ).catch(() => {});
+          }
         }
         // Feed into behavioral baseline
         if (baselineManager && event.type.includes('tool_call')) {


### PR DESCRIPTION
## Summary
- Plugin security events (`injection.detected`, `tool.blocked`, `pii.redacted`) are logged in daemon logs but never forwarded to the configured Slack webhook
- Only behavioral anomalies and kill switch activations triggered Slack alerts
- Added `sendUrgentAlert` call in the `onEvent` handler for injection/blocked/pii events, with severity, agent ID, and event details

**Before:** `injection.detected` → daemon log only, no Slack alert
**After:** `injection.detected` → daemon log + Slack alert with details

## Test plan
- [x] Verified injection.detected fires in daemon logs (OpenClaw v2026.3.8 + plugin v1.0.2)
- [ ] Verify Slack alert delivery after daemon rebuild
- [ ] Existing behavioral anomaly and kill switch alerts unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)