### PR TITLE
fix: include agentId in egress violation notifications

### DIFF
--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -44,6 +44,9 @@ export interface DaemonConfig {
     dockerDaemonConfigPath?: string;
     /** Fast egress scan interval in seconds (default: 60). Set 0 to disable. */
     egressIntervalSeconds?: number;
+    /** Regex to extract agentId from container name. First capture group = agentId.
+     *  Default: `-agent-([^-]+)-` (matches OpenClaw sandbox naming: {prefix}-agent-{id}-{hash}) */
+    containerAgentPattern?: string;
   };
   /** Webhook alerting configuration */
   alerting?: {

--- a/src/daemon/notification-manager.ts
+++ b/src/daemon/notification-manager.ts
@@ -445,6 +445,7 @@ export class NotificationManager {
 
 function summarizeEvent(event: ReceivedEvent): string {
   // Plugin injection/PII events send { patterns, phase, severity, toolName? }
+  // Egress events send { reason, remote, container }
   // Build a human-readable summary from whatever fields are available
   const parts: string[] = [];
 
@@ -458,7 +459,7 @@ function summarizeEvent(event: ReceivedEvent): string {
   if (event.data?.model) parts.push(`model: ${event.data.model}`);
 
   const detail = parts.length > 0 ? parts.join(' — ') : event.type;
-  return detail.length > 120 ? detail.slice(0, 117) + '...' : detail;
+  return detail.length > 200 ? detail.slice(0, 197) + '...' : detail;
 }
 
 function formatTime(iso: string): string {

--- a/src/daemon/runner.ts
+++ b/src/daemon/runner.ts
@@ -785,13 +785,18 @@ async function runFastEgressCheck(): Promise<void> {
     // Route egress violations through NotificationManager for batching/rate-limiting
     // instead of firing immediate webhook alerts (prevents alert spam)
     if (notificationManager) {
+      const agentPattern = config.openclaw?.containerAgentPattern
+        ? new RegExp(config.openclaw.containerAgentPattern)
+        : /-agent-([^-]+)-/;
       for (const v of result.violations) {
         const dest = v.connection.remoteHost || v.connection.remote;
         const container = v.connection.container ?? undefined;
+        const agentId = container ? agentPattern.exec(container)?.[1] : undefined;
         notificationManager.recordEvent({
           source: 'custom',
           type: 'egress.violation',
           timestamp: new Date().toISOString(),
+          agentId,
           data: {
             reason: v.reason,
             remote: dest,


### PR DESCRIPTION
## Summary

Egress violation events now include `agentId` so Slack digests show **which agent** hit **which destination** instead of "agents: unknown".

**Before:**
```
:no_entry: egress.violation (3) — agents: unknown
> Destination 2606:b740:1:20::103 not in allowlist
```

**After:**
```
:no_entry: egress.violation (3) — agents: avnish, krish
> Destination api.example.com (1.2.3.4) not in allowlist
```

## Changes

| File | Change |
|------|--------|
| `src/daemon/config.ts` | New optional `containerAgentPattern` regex config (first capture group = agentId) |
| `src/daemon/runner.ts` | Extract agentId from container name, pass on `recordEvent` |
| `src/daemon/notification-manager.ts` | Bump summary truncation 120→200 chars (egress reasons with resolved hostnames need more room) |

Default pattern `-agent-([^-]+)-` matches OpenClaw sandbox naming (`{containerPrefix}-agent-{agentId}-{hash}`). Custom deployments can override via `openclaw.containerAgentPattern` in daemon.json.

## Config example

```json
{
  "openclaw": {
    "containerAgentPattern": "-agent-([^-]+)-"
  }
}
```

No config needed for standard OpenClaw deployments — the default works out of the box.

## Test plan

- [ ] Deploy with OpenClaw sandbox containers, trigger egress violation, verify agentId appears in Slack digest
- [ ] Verify custom `containerAgentPattern` regex works for non-standard naming
- [ ] Verify non-container egress violations (gateway itself) still work with `agentId: undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)