### PR TITLE
chore: bump version to 1.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@guard0/g0",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "The control layer for AI agents — discover, assess, and govern your agent infrastructure",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- Version bump for v1.7.2 release

## Changes since v1.7.1

- fix: correct sidecar docs and add injection matched snippets (#111)
  - #108: Replace non-existent `tool-calls.jsonl` with real session JSONL paths in deployment guide
  - #110: Injection webhook events now include `matchedSnippets` with PII auto-redaction
  - OC-H-031 probe detects session transcripts as valid tool call logging
  - OpenClaw plugin version aligned to 1.0.2 across all sources

## Test plan

- [x] All CI checks passing on #111