### PR TITLE
fix(ci): migrate Slack action to v3 inputs (supersedes #171)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,12 +99,13 @@ jobs:
     if: failure() && github.event_name == 'push'
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
       - name: Notify Slack - Fail
         if: env.SLACK_WEBHOOK_URL != ''
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v3.0.5
         with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "❌ Checks Failed on main",

--- a/.github/workflows/nightly-secret-scan.yml
+++ b/.github/workflows/nightly-secret-scan.yml
@@ -238,7 +238,7 @@ jobs:
       # (TruffleHog produced output we couldn't parse). The payload distinguishes them.
       - name: Notify Slack
         if: ${{ (steps.findings.outputs.has_verified == 'true' || steps.findings.outputs.extraction_failed == 'true') && env.SLACK_WEBHOOK_URL != '' }}
-        uses: slackapi/slack-github-action@v3.0.1
+        uses: slackapi/slack-github-action@v3.0.5
         with:
           webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,13 @@ jobs:
     if: failure()
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
       - name: Notify Slack - Fail
         if: env.SLACK_WEBHOOK_URL != ''
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v3.0.5
         with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "❌ Release Failed",

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -79,12 +79,13 @@ jobs:
     if: failure() && github.event_name == 'push'
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
     steps:
       - name: Notify Slack - Fail
         if: env.SLACK_WEBHOOK_URL != ''
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@v3.0.5
         with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "❌ Checks Failed on main",


### PR DESCRIPTION
Supersedes #171. That PR bumped `slackapi/slack-github-action` 1.26.0 → 3.0.5 but **only changed the version** — which would have silently broken CI-failure alerting in 3 of 4 workflows.

## The bug
v1 read the webhook from job-level env vars (`SLACK_WEBHOOK_URL` / `SLACK_WEBHOOK_TYPE`). v3 declares explicit `webhook` / `webhook-type` **inputs** with no env fallback (verified against [v3.0.5's `action.yml`](https://github.com/slackapi/slack-github-action/blob/v3.0.5/action.yml)). `ci.yml`, `release.yml`, and `self-test.yml` still used the v1 env convention, so on v3 they'd post nothing.

It's invisible to CI: every "Notify Slack" step is `if: failure()`, so a green PR never exercises it. `nightly-secret-scan.yml` was already on v3 with the correct `with:` syntax — that's the pattern followed here.

## The fix (all 4 workflows)
- Bump to `v3.0.5` (nightly was already v3.0.1 → aligned to v3.0.5).
- Pass `webhook: ${{ env.SLACK_WEBHOOK_URL }}` and `webhook-type: incoming-webhook` as inputs.
- Keep the `SLACK_WEBHOOK_URL` env (the `if: env.SLACK_WEBHOOK_URL != ''` guard reads it); drop `SLACK_WEBHOOK_TYPE`, which v3 ignores.
- Existing `payload:` blocks stay valid — v3 still supports that input.

All 9 workflow files validated as parseable YAML. This path can't be exercised by CI (failure-only), so it was verified against the action's published input contract instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)