### PR TITLE
fix(ci): release workflow EBADENGINE — drop npm@latest upgrade, float node 22.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release to npm
 on:
   release:
     types: [published]
+  # Manual re-run for when the release-event run fails (this workflow's
+  # failure history: v1.7.1 x2, v2.0.0 x3, v2.1.0) — republishes from the
+  # default branch without deleting and re-creating the tag/release.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -17,7 +21,12 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.14.0'
+          # Float the 22.x line: a stale exact pin combined with the old
+          # `npm install -g npm@latest` step is what broke the v2.1.0 run
+          # (npm 12 requires node >=22.22.2, the pin was 22.14.0). Node 22's
+          # bundled npm (>=10.9) already supports `npm publish --provenance`,
+          # so no npm upgrade step is needed at all.
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - run: npm ci
@@ -25,8 +34,6 @@ jobs:
       - run: npm test
 
       - run: npm run build
-
-      - run: npm install -g npm@latest
 
       - run: npm publish --access public --provenance
 


### PR DESCRIPTION
The v2.1.0 release run (29833110417) failed at `npm install -g npm@latest`: npm 12 requires node >=22.22.2, but the workflow pins node 22.14.0 → `EBADENGINE` before ever reaching `npm publish`.

Fix:
- Remove the `npm install -g npm@latest` step — Node 22's bundled npm (≥10.9) already supports `npm publish --provenance`, and a floating `@latest` next to a stale exact node pin is exactly the rot vector that fired here.
- Float the node pin to `'22'` so the runner tracks the current 22.x.
- Add `workflow_dispatch` so a failed release-event run can be republished from main without deleting/re-creating the tag and release (this workflow's history: v1.7.1 ×2, v2.0.0 ×3, now v2.1.0).

After merge I'll dispatch the workflow to publish 2.1.0 — main already carries the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)