### PR TITLE
fix(ci): restore npm@latest upgrade — load-bearing for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,9 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          # Float the 22.x line: a stale exact pin combined with the old
-          # `npm install -g npm@latest` step is what broke the v2.1.0 run
-          # (npm 12 requires node >=22.22.2, the pin was 22.14.0). Node 22's
-          # bundled npm (>=10.9) already supports `npm publish --provenance`,
-          # so no npm upgrade step is needed at all.
+          # Float the 22.x line — an exact pin goes stale and eventually
+          # breaks the npm upgrade below (npm 12 requires node >=22.22.2;
+          # the old 22.14.0 pin is what failed the first v2.1.0 run).
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
@@ -34,6 +32,13 @@ jobs:
       - run: npm test
 
       - run: npm run build
+
+      # Auth is npm OIDC "trusted publishing" — no token secret is wired
+      # (NODE_AUTH_TOKEN is setup-node's placeholder). That auth path needs
+      # npm >= 11.5.1; node 22's bundled npm 10.x only covers --provenance,
+      # and falls back to the placeholder token -> E404 on PUT. This upgrade
+      # step is therefore load-bearing for publish auth. Do not remove.
+      - run: npm install -g npm@latest
 
       - run: npm publish --access public --provenance
 


### PR DESCRIPTION
Second v2.1.0 publish attempt (run 29833634612) got through tests/build/provenance and failed at the registry PUT with `E404` — npm's masked "unauthorized" for writes.

**Root cause**: this workflow has no npm token secret at all — `NODE_AUTH_TOKEN` in the logs is setup-node's literal `XXXXX-XXXXX-XXXXX-XXXXX` placeholder. Publishing authenticates via **npm OIDC trusted publishing**, which requires **npm ≥ 11.5.1**. Node 22's bundled npm 10.9.x supports `--provenance` signing but *not* OIDC auth, so it fell back to the placeholder token → rejected PUT.

So the `npm install -g npm@latest` step I removed in #190 was load-bearing for auth, not just provenance — my mistake. It only ever failed because it sat next to a stale `node-version: 22.14.0` pin (npm 12 needs node ≥ 22.22.2). With the pin now floating on `'22'`, the upgrade works again. Restored with a do-not-remove comment documenting the dependency.

Everything else from #190 stays: floating node pin, `workflow_dispatch`, main-only dispatch guard.

After merge: I re-dispatch, and verification remains `npm view @guard0/g0 version` → `2.1.0` + a live `npx @guard0/g0@2.1.0 check` smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)