### PR TITLE
docs: endpoint-page competitive fact-check — correct refuted claims, fix number drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ grade — capped at F with exit code 1 if anything known-bad is found.
 <img src="assets/demo.gif" alt="g0 endpoint and scan demo" width="720">
 </div>
 
-AI agents — and the **tools, MCP servers, and models** behind them — ship faster than anyone can track. g0 background-checks the whole estate: it discovers every component **on a laptop, in a repo, in CI, and across a fleet**, grades it against 1,128 rules in 12 domains, red-teams behavior with 1,200+ payloads, **enforces policy on live MCP traffic**, and hands you a signed, standards-mapped record you can give an auditor.
+AI agents — and the **tools, MCP servers, and models** behind them — ship faster than anyone can track. g0 background-checks the whole estate: it discovers every component **on a laptop, in a repo, in CI, and across a fleet**, grades it against 1,128 rules in 12 domains, red-teams behavior with 3,900+ payloads, **enforces policy on live MCP traffic**, and hands you a signed, standards-mapped record you can give an auditor.
 
 ## The report card
 
@@ -72,7 +72,7 @@ Point scanners check one repo. g0 covers the surfaces attackers actually use —
 |---|---|---|
 | 🖥️ | **[Endpoint](docs/endpoint-monitoring.md)** | Discover the 19 AI dev tools & MCP servers on a machine — plus agentic browsers (`--agentic-browser`) and known-malicious servers (`endpoint quarantine`, dry-run by default). No server-side scanner can see this. |
 | 🔬 | **[Scan](docs/rules.md)** | 1,128 rules across 12 domains, taint tracking, cross-file exfil analysis, and an A–F grade — for Python, TS/JS, Java, and Go. |
-| 🧪 | **[Red-team](docs/dynamic-testing.md)** | 1,200+ adversarial payloads, a 4-level judge cascade, and CVSS scoring against a live agent, HTTP endpoint, or MCP server. |
+| 🧪 | **[Red-team](docs/dynamic-testing.md)** | 3,900+ adversarial payloads, a 4-level judge cascade, and CVSS scoring against a live agent, HTTP endpoint, or MCP server. |
 | 🔌 | **[MCP supply chain](docs/mcp-security.md)** | Assess MCP servers from config + source, score per-skill trust, detect rug-pulls, and verify a package before you install it. |
 | 🛡️ | **[Runtime proxy](docs/runtime-proxy.md)** | Sit in the live path with a confidence-scored engine: checksum-validated secret detection, Exact-Data-Match, dataflow provenance — `deny`, `redact`, `coach`, or `alert` on every tool call. |
 | 🔒 | **[Protect](docs/protect.md)** | One command that installs the guardrails — MCP proxy routing, known-malicious quarantine, and [Claude Code hook enforcement](docs/hooks.md) covering built-in Bash/file-write tools no MCP proxy can see. Dry-run first, fully undoable with `protect off` — plus a resident watcher that keeps re-checking after the terminal closes. |
@@ -151,7 +151,7 @@ Pipeline taint tracking · cross-tool correlation · cross-file exfiltration · 
 <table align="center">
 <tr>
 <td align="center"><strong>1,128</strong><br><sub>Security Rules</sub></td>
-<td align="center"><strong>1,200+</strong><br><sub>Attack Payloads</sub></td>
+<td align="center"><strong>3,900+</strong><br><sub>Attack Payloads</sub></td>
 <td align="center"><strong>25</strong><br><sub>Attack Categories</sub></td>
 <td align="center"><strong>19</strong><br><sub>Dev Tools Detected</sub></td>
 <td align="center"><strong>5</strong><br><sub>Languages</sub></td>
@@ -191,13 +191,15 @@ g0 is offline-first — everything above runs locally with no account. Signing i
 | Command | Purpose |
 |---|---|
 | `g0 check [path]` | One-command background check — endpoint estate + installed skills vs the known-malicious DB, graded; exit 1 on malicious |
+| `g0 protect [--apply]` | One-command guardrails — MCP proxy + Claude Code hooks + resident watcher; dry-run first, `status`/`off`, full undo |
 | `g0 endpoint` | Discover AI dev tools & MCP server configs — `--agentic-browser`, `quarantine [--apply/--undo]` |
 | `g0 scan [path]` | Security assessment with A–F grading — `--json`, `--sarif`, `--junit`, `--ci` |
-| `g0 test` | Adversarial red-teaming — 1,200+ payloads, CVSS scoring |
+| `g0 test` | Adversarial red-teaming — 3,900+ payloads, CVSS scoring |
 | `g0 proxy install/status/fingerprint` | Runtime enforcement on live MCP traffic — deny/redact/coach/alert |
 | `g0 mcp [path]` / `mcp serve` / `mcp audit-skills` | Assess MCP servers · run g0 as an MCP server · per-skill trust audit |
 | `g0 inventory [path]` | AI-BOM — signed CycloneDX 1.6, content-addressed |
 | `g0 fleet scan/status/drift/list` | Estate roll-up and drift across repos & machines |
+| `g0 sentinel scan/collect/report` | MDM-deployed fleet snapshots — AI footprint + PII-exposure evidence + governance verdicts, org-wide report _(preview)_ |
 | `g0 attest [path]` | Signed, standards-mapped attestation pack |
 | `g0 flows [path]` | Execution-path mapping and toxic-flow detection |
 | `g0 gate [path]` | CI/CD gate — thresholds + diff-based regression mode |
@@ -215,6 +217,7 @@ Every command supports `--json`. Full reference in [the docs](docs/).
 | | |
 |---|---|
 | [Getting Started](docs/getting-started.md) | [Runtime Proxy](docs/runtime-proxy.md) |
+| [Runtime Protection — `g0 protect`](docs/protect.md) · [Hooks](docs/hooks.md) | [MDM AI-Footprint Governance](docs/solutions/mdm-ai-footprint-governance.md) |
 | [Rules Reference](docs/rules.md) · [Custom Rules](docs/custom-rules.md) | [MCP Security](docs/mcp-security.md) · [g0 as an MCP Server](docs/mcp-server.md) |
 | [Scoring](docs/scoring.md) · [Findings](docs/findings.md) | [Endpoint Assessment](docs/endpoint-monitoring.md) |
 | [AI Inventory](docs/inventory.md) · [Attestation](docs/attestation.md) | [Fleet Control Plane](docs/fleet.md) · [Fleet Sentinel](docs/sentinel.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,8 @@ Welcome to the g0 documentation. g0 runs background checks on your AI agents —
 
 | | | | |
 |:---:|:---:|:---:|:---:|
-| **1,128** | **1,200+** | **1,184+** | **10** |
-| Security Rules | Adversarial Payloads | Malicious Skill IOCs | Framework Parsers |
+| **1,128** | **3,900+** | **18** | **10** |
+| Security Rules | Adversarial Payloads | MCP Clients Covered | Framework Parsers |
 | **10** | **5** | **25** | **20** |
 | Compliance Standards | Languages | Attack Categories | Encoding Mutators |
 
@@ -30,13 +30,15 @@ Welcome to the g0 documentation. g0 runs background checks on your AI agents —
 - [**AI Asset Inventory**](inventory.md) — Discover and document all AI components (AI-BOM)
 - [**MCP Security**](mcp-security.md) — Assess MCP servers, detect rug-pulls, pin tool descriptions
 - [**g0 as an MCP Server**](mcp-server.md) — Run g0 inside Claude Code/Cursor/Windsurf via `g0 mcp serve`
-- [**Dynamic Testing**](dynamic-testing.md) — 1,200+ adversarial payloads, adaptive attacks, CVSS scoring, 25 attack categories, 20 mutators
+- [**Dynamic Testing**](dynamic-testing.md) — 3,900+ adversarial payloads, adaptive attacks, CVSS scoring, 25 attack categories, 20 mutators
 - [**Framework Guide**](frameworks.md) — Per-framework detection, patterns, and findings
 - [**Framework Remediation Guides**](frameworks/README.md) — Framework-specific fixes for common g0 findings: [MCP](frameworks/mcp.md)
 
 ## Integration
 
 - [**Endpoint Assessment & Monitoring**](endpoint-monitoring.md) — Multi-layer endpoint scanning (network, artifacts, forensics, browser), scoring, remediation, drift detection, fleet-wide daemon
+- [**Runtime Protection (`g0 protect`)**](protect.md) — One command to install the guardrails across surfaces (MCP proxy, Claude Code hooks, resident watcher): dry-run by default, full undo
+- [**Claude Code Hook Enforcement (`g0 hook`)**](hooks.md) — PreToolUse/PostToolUse hooks that run Claude Code's built-in tools (Bash, file writes, WebFetch) through the same policy engine as the proxy
 - [**Runtime Proxy (`g0 proxy`)**](runtime-proxy.md) — Policy-enforcing MCP man-in-the-middle: allow/deny/redact/coach, EDM fingerprinting, dataflow tracking, confidence-fusion Policy DSL v2
 - [**CI/CD Integration**](ci-cd.md) — GitHub Actions, GitLab CI, Jenkins, pre-commit hooks
 - [**OpenClaw Security**](openclaw-security.md) — Static scanning, supply-chain auditing, adversarial testing, live hardening, deployment audit

--- a/docs/dynamic-testing.md
+++ b/docs/dynamic-testing.md
@@ -8,7 +8,7 @@ Dynamic testing complements static scanning — while `g0 scan` analyzes source 
 
 ```mermaid
 flowchart LR
-    A[1,200+ Payloads] --> B[Provider]
+    A[3,900+ Payloads] --> B[Provider]
     B --> C[Live Agent]
     C --> D[Response]
     D --> E[4-Level Judge]
@@ -20,7 +20,7 @@ flowchart LR
 
 | Metric | Count |
 |--------|-------|
-| Attack payloads | 1,200+ core payloads |
+| Attack payloads | 3,900+ core payloads |
 | Attack categories | 25 (prompt injection, jailbreak, data exfiltration, tool abuse, MCP attacks, and more) |
 | Harmful subcategories | 31 |
 | Payload mutators | 20 (with stacking) |
@@ -89,7 +89,7 @@ g0 test --target http://localhost:3000/api/chat --system-prompt-file ./prompts/s
 
 ## Attack Categories
 
-g0 includes core adversarial payload categories totaling 1,200+:
+g0 includes core adversarial payload categories totaling 3,900+:
 
 | Category | Payloads | What It Tests |
 |----------|----------|--------------|
@@ -631,7 +631,7 @@ Default is 30 seconds per payload.
 ### Common Workflows
 
 ```bash
-# Full comprehensive test (all 1,200+ payloads)
+# Full comprehensive test (all 3,900+ payloads)
 g0 test --target http://localhost:3000/api/chat
 
 # OpenClaw security test (CVE-2026-28363, CVE-2026-25253, ClawHavoc IOC, SOUL.md/MEMORY.md attacks)
@@ -691,7 +691,7 @@ g0 test --target http://localhost:3000/api/chat --auto . --ai
 
 ### What g0 Finds vs What You're Missing
 
-g0 tests with 1,200+ core payloads across prompt injection, jailbreak, data exfiltration, tool abuse, and MCP attacks. This catches the most common vulnerability classes.
+g0 tests with 3,900+ core payloads across prompt injection, jailbreak, data exfiltration, tool abuse, and MCP attacks. This catches the most common vulnerability classes.
 
 However, sophisticated AI agents often resist static payloads while remaining vulnerable to adaptive, multi-turn attacks that learn from the target's responses. In testing, adaptive strategies typically uncover 2-3x more vulnerabilities:
 

--- a/docs/solutions/mdm-ai-footprint-governance.md
+++ b/docs/solutions/mdm-ai-footprint-governance.md
@@ -29,16 +29,30 @@ there, a governance policy flags non-compliant tools and drives removal — with
 MDM doing the enforcing by default. Inventory first; governance next; enforcement
 where you opt in.
 
-## Why endpoint-native
+## Why endpoint-native — and why independent
 
-The shadow-AI market mostly looks *away* from the machine. **Network/proxy** tools
-(Zscaler, Netskope, Microsoft Defender for Cloud Apps) see *traffic* to AI domains;
-**SaaS-API/OAuth** tools (Nudge, Wing, Grip) see *grants and logins*. Both are
-useful, and g0 is complementary to them — but neither gives you a per-machine
-**asset inventory** of installed AI apps + coding agents + browser extensions + MCP
-configs, unified with **local PII-exposure evidence** and governance. That endpoint,
-local-first view — positioned as an independent auditor of your estate rather than an
-inline proxy — is where the sentinel sits.
+Most shadow-AI tooling looks *away* from the machine. **Network/proxy** tools
+(Zscaler AI Access Security, Microsoft Defender for Cloud Apps, WitnessAI) see
+*traffic* to AI domains; **SaaS-API/OAuth** tools (Nudge, Wing, Grip) see *grants,
+logins and browser signals*. Both are useful, and g0 is complementary to them.
+
+The endpoint itself is now contested ground: EDR, SSE and DLP platforms are adding
+on-device AI discovery (CrowdStrike Shadow AI Discovery, Palo Alto's Koi-based
+"agentic endpoint security", SentinelOne/Prompt, Cyberhaven, Netskope One Client,
+Harmonic). All of them are persistent-agent platforms oriented to runtime
+governance, inline DLP, or supply-chain risk — another resident platform to buy
+into, grading an estate the same vendor also enforces.
+
+None of them ship what the sentinel is: an **independent, open-source audit**,
+pushed through the MDM you already run, that unifies the full per-machine AI
+footprint — installed AI apps, coding agents, browser AI extensions, MCP configs,
+**and Office add-ins** — and attaches **local PII-exposure evidence** to every tool
+(what it *can* reach × what *did* flow, as classes + counts, never values). No new
+management plane, no traffic interception, no vendor grading its own homework — an
+auditor of record for your AI estate, with the receipts written down.
+
+> Competitive claims on this page are verified against vendor primary sources —
+> see the [sourced fact-check (2026-07-30)](../superpowers/research/2026-07-30-endpoint-page-competitive-fact-check.md).
 
 ## How it works
 
@@ -144,8 +158,8 @@ The agent is identical everywhere; each MDM just needs a thin recipe:
 | MDM | Deploy | Schedule | Remediate |
 |---|---|---|---|
 | **ManageEngine Endpoint Central** | Software Deployment (MSI/PKG) | Custom Script + installer-registered task | Prohibited Software · Add-on/Extension Control · Application Control |
-| **Jamf Pro (macOS)** | Policy + notarized PKG | LaunchDaemon config profile | Jamf policies |
-| **Microsoft Intune** | Win32 app (`.intunewin`) + PowerShell | Scheduled Task | ADMX / settings-catalog blocklist |
+| **Jamf Pro (macOS)** | Policy + PKG (notarize for PreStage / user-run installs) | LaunchDaemon laid down by the PKG; Managed Login Items profile to prevent tamper | Jamf policies |
+| **Microsoft Intune** | Win32 app (`.intunewin`) + PowerShell | Script-registered Scheduled Task, or Intune Remediations | ADMX / settings-catalog blocklist |
 | **Kandji / Mosyle / Workspace ONE** | Same PKG/MSI + config profile | Config profile / script | Vendor policy equivalents |
 
 > **ManageEngine note:** confirm you run **Endpoint Central** (agent-based), not

--- a/docs/superpowers/research/2026-07-30-endpoint-page-competitive-fact-check.md
+++ b/docs/superpowers/research/2026-07-30-endpoint-page-competitive-fact-check.md
@@ -1,0 +1,268 @@
+# Competitive fact-check — endpoint page & sentinel spec (2026-07-30)
+
+**Scope.** Every competitive claim in
+[`docs/solutions/mdm-ai-footprint-governance.md`](../../solutions/mdm-ai-footprint-governance.md)
+("Why endpoint-native", per-MDM recipes) and the researched positioning section of
+[`docs/superpowers/specs/2026-07-23-g0-sentinel-fleet-ai-footprint-design.md`](../specs/2026-07-23-g0-sentinel-fleet-ai-footprint-design.md)
+(§"Competitive positioning", §16 sources), verified against live vendor sources on
+2026-07-29/30 by five parallel research passes.
+
+**Headline verdicts.**
+
+1. The two-camp taxonomy (network/proxy vs SaaS-API) was accurate when researched but was
+   **overtaken by events in June–July 2026**, partly *before* the spec's 2026-07-23 date.
+2. **"Only Harmonic Security and Lanai ship true endpoint agents" is WRONG as written.**
+   Nightfall, Cyberhaven, SentinelOne/Prompt (Aug 2025), Koi→Palo Alto (Apr 2026), and
+   CrowdStrike (announced Mar 2026) all shipped or announced endpoint agents with AI
+   visibility before the claim date.
+3. **"The inventory positioning is unoccupied" is false in its strong form** — Koi/PANW
+   branded the category "Agentic Endpoint Security" — but a *narrower* wedge survives
+   (see "What survives" below).
+4. All seven ManageEngine Endpoint Central capability claims are **accurate**; the Jamf and
+   Intune recipe rows need corrections.
+
+---
+
+## 1. Network/proxy camp ("they see traffic to AI domains")
+
+### Zscaler — claimed "Zscaler AI Access" · PARTIALLY ACCURATE
+- Correct current name: **AI Access Security** (siblings: AI Asset Management/AI-SPM, AI
+  Guardrails, AI Red Teaming; umbrella "AI Protect").
+  https://www.zscaler.com/products-and-solutions/ai-access-security ·
+  https://www.zscaler.com/resources/data-sheets/zscaler-gen-ai-security-at-a-glance.pdf ·
+  https://www.zscaler.com/products-and-solutions/ai-security
+- Mechanism claim (SSE inline inspection, traffic-based GenAI discovery) accurate for the
+  core product. https://www.zscaler.com/blogs/product-insights/shadow-ai-shadow-agents-visibility-control
+- **Overtaken:** June 9, 2026 (Zenith Live) Zscaler announced **"Endpoint AI Security"** —
+  "AI-related threats on employee devices, including risks hidden in browsers, plugins,
+  extensions, and local AI tools" — plus AI Asset Management endpoint visibility, AI Broker
+  (MCP/A2A + Agent Registry), AI Access Graph. **No GA dates in the release** — announced,
+  not proven shipping.
+  https://www.zscaler.com/press/zscaler-unveils-new-product-innovations-secure-agentic-ai ·
+  https://www.globenewswire.com/news-release/2026/06/09/3309070/0/en/Zscaler-Unveils-New-Product-Innovations-to-Secure-Agentic-AI.html ·
+  https://siliconangle.com/2026/06/09/zscaler-launches-ai-broker-endpoint-ai-security-ai-agents/ ·
+  https://futurumgroup.com/insights/zscaler-bets-on-agentic-ai-security-at-zenith-live-2026/
+- Client Connector itself remains traffic forwarding + posture checks, not AI inventory.
+  https://help.zscaler.com/zscaler-client-connector/about-device-posture-profiles
+
+### Netskope — claimed "AI Command Center" · NAME ACCURATE; "traffic-only" framing WRONG
+- **Netskope One AI Command Center** exists — announced and GA **June 2, 2026** (predates
+  the spec). https://www.netskope.com/products/ai-command-center ·
+  https://www.netskope.com/press-releases/netskope-unveils-ai-command-center-delivering-comprehensive-ai-discovery-and-correlated-risk-intelligence-with-fully-coordinated-agentic-response ·
+  https://www.networkworld.com/article/4180200/netskope-introduces-ai-command-center-to-monitor-and-secure-enterprise-ai-sprawl.html
+- Three discovery mechanisms, two of them NOT proxy: inline NewEdge SSE; an eBPF agent for
+  VMs/K8s; and **"Netskope One Client … scanning installed applications, running processes,
+  and listening ports on managed endpoints to identify known AI agents, local models, and
+  browser extensions."** The endpoint-blind framing was already wrong at write time.
+  https://www.helpnetsecurity.com/2026/06/03/netskope-one-ai-command-center/
+- Background: CCI risk-scores 370+ genAI apps. https://docs.netskope.com/en/evaluate-apps/ ·
+  https://www.netskope.com/products/securing-generative-ai
+
+### WitnessAI · ACCURATE
+- Network-level, deliberately agentless ("without requiring endpoint agents or browser
+  extensions"); Observe/Control/Protect modules; prompt+response visibility; Jan 2026 agent
+  activity monitoring. https://witness.ai/ · https://witness.ai/product/ ·
+  https://witness.ai/blog/introducing-witnessai-agentic-security-extending-the-confidence-layer-to-ai-agents/ ·
+  https://witness.ai/blog/best-zscaler-alternatives-ai-security-governance/
+- Status: independent; $58M round Jan 13, 2026 (total $85.5M).
+  https://www.prnewswire.com/news-releases/witnessai-raises-58-million-for-global-expansion-and-announces-new-ways-to-secure-ai-agents-302659319.html
+
+### Microsoft Defender for Cloud Apps · ACCURATE on discovery; framing needs precision
+- Shadow-AI discovery is traffic-based (firewall/proxy logs + Defender for Endpoint
+  *network transaction* logs — telemetry, not installed-software enumeration).
+  https://learn.microsoft.com/en-us/defender-cloud-apps/mde-integration ·
+  https://techcommunity.microsoft.com/blog/microsoftthreatprotectionblog/discover-monitor-and-protect-the-use-of-generative-ai-apps/3999228
+- **But** Defender Vulnerability Management ships installed-software inventory AND a
+  browser-extension assessment (permissions, risk, hunting tables) — generic, with **no
+  AI classification layer**. Blanket "Microsoft sees traffic, not installed inventory" is
+  wrong; "Microsoft's shadow-AI *feature* is traffic-based" is right.
+  https://learn.microsoft.com/en-us/defender-vulnerability-management/tvm-browser-extensions
+- Purview DSPM for AI monitors AI usage incl. on endpoints via the Purview **browser
+  extension** + onboarded devices; Endpoint DLP does paste/upload controls for AI sites
+  (data-flow, not inventory). https://learn.microsoft.com/en-us/purview/dspm-for-ai ·
+  https://learn.microsoft.com/en-us/purview/endpoint-dlp-learn-about ·
+  https://learn.microsoft.com/en-us/purview/ai-microsoft-purview-supported-sites
+- Missed: Entra Global Secure Access "Shadow AI discovery" (June 2026 doc) — network-based
+  GenAI/MCP/model-API discovery + Generative AI Insights (TLS inspection, prompt logging).
+  https://learn.microsoft.com/en-us/entra/global-secure-access/concept-shadow-ai-discovery ·
+  https://learn.microsoft.com/en-us/entra/global-secure-access/concept-generative-ai-insights
+
+---
+
+## 2. SaaS-API/OAuth camp ("agentless — they see grants and logins")
+
+### Nudge Security · PARTIALLY ACCURATE (browser-blind framing outdated)
+- Core agentless email/OAuth/IdP discovery accurate.
+  https://www.nudgesecurity.com/features/how-it-works ·
+  https://www.nudgesecurity.com/features/saas-discovery
+- **But Nudge ships a first-party browser extension since June 11, 2025** (MDM-deployable;
+  logins, OAuth grants, file uploads, in-browser blocking/AI policy) — its extension
+  governance depends on it. https://www.nudgesecurity.com/features/browser-extension ·
+  https://www.prnewswire.com/news-releases/nudge-security-extends-saas-and-generative-ai-security-governance-to-the-browser-302478264.html
+- July 15, 2026: "Browser Extension Risk Analyst" + "OAuth Grant Risk Analyst" agents —
+  surfaces risky third-party extensions on employee devices.
+  https://www.nudgesecurity.com/press/nudge-security-unveils-ai-agents-to-mitigate-escalating-risks-from-hidden-oauth-grants-and-browser-extensions
+- AI agent discovery (Agentforce, Copilot Studio, MCP connections, Cursor automations…):
+  https://www.nudgesecurity.com/features/ai-agent-discovery ·
+  https://www.helpnetsecurity.com/2026/05/28/nudge-browser-based-agentic-ai-security/
+- $22.5M Series A Nov 18, 2025; still independent.
+  https://www.nudgesecurity.com/press/nudge-security-raises-22-5m-series-a-to-secure-workforce-ai-and-saas
+- Endpoint reach stops at the browser; no OS-level agent, no installed-software inventory.
+
+### Wing Security · ACCURATE
+- Agentless API-first ("no endpoint agents, no browser extensions"); AI discovery of tools,
+  agents, embedded AI. https://wing.security/platform/ · https://wing.security/home/ ·
+  https://wing.security/use-cases/ai-discovery/
+- Sept 30, 2025: repositioned AI-security-centric. Still independent, last round 2022.
+  https://www.globenewswire.com/news-release/2025/09/30/3158498/0/en/Wing-Security-Evolves-into-an-AI-Security-Centric-Company-Extends-Platform-to-Govern-and-Protect-SaaS-AI-Applications.html ·
+  https://www.crunchbase.com/organization/wing-security
+
+### Grip Security · PARTIALLY ACCURATE
+- Email/IdP-based SaaS discovery accurate.
+  https://community.sailpoint.com/t5/Connector-Directory/Grip-Security-Connector-Extending-SaaS-Identity-Risk-Management/ta-p/261514
+- **But "Grip Extend" first-party browser extension exists** (cookies, requests, hidden-SaaS
+  discovery). https://grip3818.zendesk.com/hc/en-us/articles/24305903062685-Grip-Extend-Security-and-Data-Architecture ·
+  https://addons.mozilla.org/en-US/firefox/addon/grip-extend/
+- AI governance limited; ITDR 2.0 (June 3, 2025) adds malicious-extension detection.
+  https://www.reco.ai/compare/grip-security-vs-obsidian-security ·
+  https://securityboulevard.com/2025/06/stay-ahead-of-identity-threats-with-grip-itdr-2-0-grip/
+- Independent; $66M total (Series B Aug 2023).
+  https://techcrunch.com/2023/08/22/grip-security-raises-41m-to-help-enterprises-manage-their-saas-identity-risk/
+
+**Camp verdict:** none deploys an OS-level agent or inventories installed desktop AI
+tooling — the core differentiation holds — but "agentless/SaaS-side" is now wrong for
+Nudge and Grip at the browser layer.
+
+---
+
+## 3. Endpoint camp ("only Harmonic and Lanai; usage-monitoring, not inventory")
+
+### Harmonic Security · PARTIALLY ACCURATE, then overtaken within days
+- Historically a **browser extension**, not an endpoint agent ("Harmonic Protect is a
+  lightweight browser extension…", Jan 2026 snapshot:
+  https://web.archive.org/web/20260120114456/https://www.harmonic.security/products/harmonic-protect).
+  So "endpoint desktop client" overstated the past; inline-DLP characterization accurate.
+- Now four surfaces (extension, native desktop client, MCP gateway, embedded-SaaS
+  detection), rebranded Explore/Guide/Command. https://www.harmonic.security/
+- **"Not inventory" is now WRONG:** Harmonic's Endpoint Agent page — first archived
+  **2026-07-26**, the week the spec was written — inventories "every native AI app,
+  AI-first IDE, CLI tool, locally hosted model, and direct inference API call" (Claude
+  Desktop, Cursor, Claude Code, Ollama, MCP servers; OpenAI/Anthropic/Bedrock/Azure calls
+  tied to process+user). https://www.harmonic.security/solutions/endpoint-ai-security
+  (CDX: sole snapshot 20260726045451) · https://aisecurityplatform.com/reviews/harmonic/
+- Funding unchanged: $17.5M Series A Oct 2024.
+  https://www.harmonic.security/resources/harmonic-security-raises-17-5-million-series-a-to-accelerate-zero-touch-data-protection-to-market
+
+### Lanai · ACCURATE
+- Edge-based AI Observability Agent, MDM-deployed <24h, on-device models, prompt-level
+  visibility; runtime-derived (not static inventory).
+  https://www.prnewswire.com/news-releases/new-platform-discovers-89-of-enterprise-ai-use-is-invisible-to-it-teams-as-lanai-launches-edge-based-ai-observability-agent-302552910.html ·
+  https://siliconangle.com/2025/09/10/lanais-edge-based-observability-agents-aim-shut-shadow-ai/
+- April 2026 pivot to "AI @ Work Operating System" (ROI-first).
+  https://finance.yahoo.com/sectors/technology/articles/lanai-launches-ai-operating-system-133000943.html ·
+  live site https://www.withlanai.com/ (note: lanai.ai is a dead Wix 404 — fix any links).
+- Seed-stage ($11.5M total); no Series A found.
+
+### Prompt Security · listing it as an independent startup is STALE
+- **Acquired by SentinelOne**: announced Aug 5, 2025, closed Sept 5, 2025, ~$250M
+  (~$133.6M cash + stock, per 10-Q).
+  https://www.sentinelone.com/press/sentinelone-to-acquire-prompt-security-to-advance-genai-security/ ·
+  https://www.sec.gov/Archives/edgar/data/1583708/000158370825000159/s-20251031.htm ·
+  https://www.darkreading.com/endpoint-security/sentinelone-acquires-ai-startup-prompt-security
+- Deploys browser extensions + a lightweight endpoint agent (IDE sync) + gateway/SDK + MCP
+  gateway. Markets "Inventory every AI tool and code assistant in use" (15,000+ services),
+  shadow MCP discovery, Copilot/Cursor/Claude Code governance — on an EDR install base.
+  https://www.sentinelone.com/platform/securing-ai-prompt/ ·
+  https://prompt.security/solutions/employees ·
+  https://www.sentinelone.com/blog/a-new-chapter-for-ai-and-cybersecurity-sentinelone-acquires-prompt-security/
+
+---
+
+## 4. Adversarial pass — endpoint agents the page doesn't name
+
+Direct refutations of "only Harmonic and Lanai" (all pre-2026-07-23):
+
+| Vendor | Device footprint | AI visibility | Key sources |
+|---|---|---|---|
+| **CrowdStrike** "Shadow AI Discovery for Endpoint" (ann. Mar 23, 2026; GA unverified — future-products disclaimer) | Falcon sensor | "AI applications, agents, LLM runtimes, MCP servers, and development tools running across endpoints" + EDR AI Runtime Protection | https://www.crowdstrike.com/en-us/press-releases/crowdstrike-establishes-the-endpoint-as-the-epicenter-for-ai-security/ · https://siliconangle.com/2026/03/23/crowdstrike-targets-ai-security-gap-falcon-platform-expansion-rsac-conference/ |
+| **Koi Security → Palo Alto** (intent Feb 17, 2026; closed Apr 14, 2026, ~$400M; category branded "Agentic Endpoint Security") | Endpoint platform, macOS/Win/Linux | Tracks "every application, code or OS package, extension, AI model, AI agent, and MCP the moment it shows up"; browser + VS Code/OpenVSX extensions; allow/block/remediate | https://www.koi.ai/platform · https://www.paloaltonetworks.com/company/press/2026/palo-alto-networks-completes-acquisition-of-koi-to-secure-the-agentic-endpoint · https://www.calcalistech.com/ctechnews/article/nu6ccmpyw |
+| **Cyberhaven** "Agentic AI Security" (PR Mar 24, 2026; sensor long-shipping) | Endpoint data-lineage sensor | "Discover and inventory AI agents, MCP servers, and connections"; shadow AI across endpoints, browsers, CLIs, IDEs incl. Claude Code/Codex; Risk IQ | https://www.cyberhaven.com/press-releases/cyberhaven-closes-the-ai-security-gap-amid-the-meteoric-rise-of-agentic-ai · https://www.cyberhaven.com/product/ai-security · https://www.cyberhaven.com/blog/endpoint-ai-agents-blind-spot |
+| **SentinelOne/Prompt** (Aug–Sept 2025) | Agent + browser extensions | See §3 above | (see §3) |
+| **Nightfall AI** | Endpoint agent + browser plugin | Real-time exfil blocking to AI apps (DLP, not inventory) — still falsifies "only two endpoint agents" | https://www.nightfall.ai/integrations/browser-dlp-and-endpoint-dlp · https://www.prnewswire.com/news-releases/nightfall-unveils-ai-browser-security-solution-to-stop-data-exfiltration-in-real-time-302666771.html |
+| **Snyk Agent Scan / mcp-scan** | MDM-deployable scanner | Reads local MCP/agent configs (Claude Code/Desktop, Cursor, Gemini CLI, Windsurf); risk analysis; "MDM-based deployment … with observability on Snyk EVO" — the closest philosophical twin to `g0 sentinel`, dev-tool-scoped | https://github.com/snyk/agent-scan · https://invariantlabs-ai.github.io/docs/mcp-scan/ |
+
+Partial overlaps (device-resident but usage/DLP-centric or single-surface): **LayerX**
+(extension-only AI app + AI-extension inventory: https://layerxsecurity.com/ ·
+https://layerxsecurity.com/genai-dlp/), **Island AI Protect** (Mar 17, 2026; browser +
+desktop-app visibility: https://www.island.io/ai), **Lasso Security** (extension + IDE
+plugin + CrowdStrike Falcon telemetry integration Jan 26, 2026:
+https://www.lasso.security/blog/ai-agents-discovery-lasso-crowdstrike-falcon), **Microsoft
+stack** (usage-DLP; raw inventory unmerged/un-AI-tagged — see §1), **Fleet/osquery** (MCP
+query pack + `mcp_listening_servers` table; primitives, not a governance product:
+https://fleetdm.com/reports/get-mcp-client-configurations ·
+https://fleetdm.com/tables/mcp_listening_servers), **Cato+Aim** (Sept 3, 2025; network
+flows, client is a tunnel: https://www.catonetworks.com/news/cato-acquires-aim-security-to-extend-sase-leadership-and-secure-enterprise-ai-transformation/),
+**1Password XAM/Kolide** (access-based shadow-AI: https://1password.com/blog/discover-and-secure-shadow-it-with-1password-extended-access-management),
+**Archipelo** (dev-scoped AI tool tracking: https://archipelo.com/developer-attribution).
+MDMs themselves (Jamf/Kandji): generic app inventory, no AI-tagged product found.
+(Chrome Enterprise Premium: not verified this pass.)
+
+### What survives — the defensible wedge
+
+1. **Inventory × local PII-exposure evidence is still unoccupied.** No vendor found pairs
+   per-machine AI-footprint inventory with static, local evidence of what PII sits in AI
+   tool artifacts (histories/configs/reachable files). DLP rivals inspect data in flight.
+2. **Office add-ins**: no AI-inventory competitor covers them. Narrow but unique.
+3. **MDM-pushed, non-resident-platform audit**: contested only by Snyk Agent Scan
+   (MCP-configs, dev-focused) — everyone else is a persistent agent platform.
+4. **Independent auditor-of-record + OSS + local-first**: every direct competitor is an
+   EDR/DLP/SSE platform grading its own estate; none are open source; none are local-first.
+5. CrowdStrike's capability is announced-not-GA; Zscaler's has no GA date — a shipping
+   window exists, measured in months.
+
+**Required rewrite:** drop "only Harmonic and Lanai" entirely; stop describing Harmonic as
+usage-only; update Nudge/Grip browser-extension reality; position explicitly against
+"Agentic Endpoint Security" platforms: *"Multiple endpoint agents now discover AI apps,
+coding agents, and MCP servers (CrowdStrike, Cyberhaven, SentinelOne/Prompt, Koi/Palo
+Alto) — all persistent-agent platforms doing runtime governance or supply-chain risk. None
+ship an MDM-pushed, per-machine AI-footprint audit spanning installed AI apps, coding
+agents, browser AI extensions, MCP configs, AND Office add-ins, with local PII-exposure
+evidence attached to each finding, from an independent open-source auditor."*
+
+---
+
+## 5. MDM capability claims (deployment table)
+
+All ManageEngine Endpoint Central claims verified ACCURATE against vendor docs:
+
+| Claim | Verdict | Key source |
+|---|---|---|
+| EC-only custom-script engine; MDM Plus lacks scripts (has custom *profiles* only) | ACCURATE | https://www.manageengine.com/products/desktop-central/help/configuration_templates/script_repository.html · https://www.manageengine.com/mobile-device-management/faq.html |
+| Software Deployment: MSI + PKG/DMG (and more) | ACCURATE | https://www.manageengine.com/products/desktop-central/software-installation-supported-executables-how-to.html |
+| No native fleet-wide file-pull; File Scan = type census (manual per-device transfer via remote control exists) | ACCURATE | https://www.manageengine.com/products/desktop-central/demo/inventory/file-scan.html · https://www.manageengine.com/products/desktop-central/api/ |
+| Prohibited Software auto-uninstall (MSI default; EXE needs silent switches; ~90-min cycle) | ACCURATE | https://www.manageengine.com/products/desktop-central/help/inventory/configure_prohibited_software.html |
+| Browser Add-on Restriction blocks AND removes extensions (native EC module, not external integration) | ACCURATE | https://www.manageengine.com/products/desktop-central/help/browser-security/addon-restriction.html |
+| Application Control blocks executables (Security-edition licensing) | ACCURATE | https://www.manageengine.com/products/desktop-central/help/application-control/ac-overview.html |
+| REST API v1.4 (newer modules under parallel `/dcapi/`) | ACCURATE | https://www.manageengine.com/products/desktop-central/api/ |
+
+Corrections needed in the per-MDM recipe table:
+
+- **Jamf**: notarization is NOT required for policy-based PKG installs (only for
+  PreStage/DEP or user-run installs; notarizing is still good practice); a config profile
+  does not install/schedule a LaunchDaemon — the PKG lays down the plist, and the Service
+  Management (Managed Login Items) profile only tamper-protects it (no built-in Jamf editor).
+  https://docs.jamf.com/10.42.0/jamf-pro/documentation/Execution_Frequency_for_Policies.html ·
+  https://learn.jamf.com/en-US/bundle/technical-articles/page/Uploading_a_Configuration_Profile_for_Managed_Login_Items.html ·
+  https://community.jamf.com/general-discussions-2/unsigned-package-deployment-30013
+- **Intune**: no native scheduled-task payload — either the deployed script registers a
+  Windows Scheduled Task, or use Remediations (Ent/Edu/VDA licensing; Once/Hourly/Daily).
+  .intunewin + PowerShell + Edge/Chrome extension blocklists via Settings Catalog accurate.
+  https://learn.microsoft.com/en-us/intune/app-management/deployment/create-win32-package ·
+  https://learn.microsoft.com/en-us/intune/device-management/tools/deploy-remediations ·
+  https://learn.microsoft.com/en-us/deployedge/microsoft-edge-policies/extensioninstallblocklist
+
+---
+
+*Method note: five parallel research passes (network camp, SaaS camp, endpoint camp,
+adversarial counterexample hunt, MDM claims) run 2026-07-29/30 with live web verification;
+vendor primary sources preferred, Wayback CDX used for launch-timing evidence.*

--- a/docs/superpowers/specs/2026-07-23-g0-sentinel-fleet-ai-footprint-design.md
+++ b/docs/superpowers/specs/2026-07-23-g0-sentinel-fleet-ai-footprint-design.md
@@ -39,6 +39,17 @@ Deliverable: a demo-able closed loop —
 
 ### Competitive positioning (why this is worth building) — [RESEARCHED]
 
+> **[CORRECTED 2026-07-30]** The paragraph below was overtaken by events — partly before
+> this spec's write date. Netskope shipped endpoint AI scanning (AI Command Center, GA
+> 2026-06-02); Zscaler announced Endpoint AI Security (2026-06-09, no GA date); and "only
+> Harmonic and Lanai ship true endpoint agents" is refuted: CrowdStrike Shadow AI Discovery
+> (announced 2026-03-23), Koi→Palo Alto "agentic endpoint security" (closed 2026-04-14,
+> ~$400M), Cyberhaven, SentinelOne/Prompt (closed 2025-09), and Nightfall all pre-date this
+> spec; Harmonic added per-device AI inventory (~2026-07-26). The **surviving** wedge:
+> inventory × local PII-exposure evidence, Office add-ins, MDM-pushed non-resident audit,
+> independent OSS auditor positioning. Full sourced fact-check:
+> `docs/superpowers/research/2026-07-30-endpoint-page-competitive-fact-check.md`.
+
 The shadow-AI market splits into two camps that both look **away from the machine**:
 **network/proxy** (Zscaler AI Access, Netskope AI Command Center, WitnessAI, Microsoft
 Defender for Cloud Apps — they see *traffic* to AI domains) and **SaaS-API/OAuth/IdP** (Nudge


### PR DESCRIPTION
## Why

Five parallel sourced research passes (2026-07-29/30) verified every competitive claim on the MDM/endpoint solution page and the sentinel spec against vendor primary sources. The load-bearing claim — "only Harmonic and Lanai ship true endpoint agents; the inventory positioning is unoccupied" — was **already false on the spec's write date**, and the docs carried stale capability numbers. For a product positioned as an *auditor of record*, our own pages have to audit clean.

## What was refuted (full citations in the new research doc)

- **Koi Security → Palo Alto Networks** closed 2026-04-14 (~$400M) — PANW branded the exact category ("Agentic Endpoint Security": apps, extensions, AI models/agents, MCPs per device)
- **CrowdStrike Shadow AI Discovery for Endpoint** announced 2026-03-23 (AI apps, agents, LLM runtimes, MCP servers on the Falcon sensor; GA unverified)
- **Cyberhaven** — endpoint sensor inventories AI agents/MCP servers incl. Claude Code/Codex
- **SentinelOne/Prompt Security** — closed 2025-09-05 (~$250M); markets "inventory every AI tool"
- **Netskope One AI Command Center** GA 2026-06-02 — client scans installed apps/processes/ports for AI agents, local models, extensions
- **Zscaler Endpoint AI Security** announced 2026-06-09 (no GA date)
- **Harmonic** launched per-device AI inventory (page live ~2026-07-26); **Nudge/Grip** ship first-party browser extensions (no longer purely "agentless")

**Verified surviving wedge** (now the only claims the page makes): per-machine inventory × local PII-exposure evidence, Office add-in coverage, MDM-pushed non-resident audit, independent open-source auditor positioning.

## Changes

- **`docs/solutions/mdm-ai-footprint-governance.md`** — "Why endpoint-native — and why independent" rewritten around the verified wedge; names the EDR/SSE endpoint entrants honestly; links the sourced fact-check. Jamf recipe corrected (notarization only for PreStage/user-run installs; PKG installs the LaunchDaemon, Managed Login Items profile tamper-protects). Intune recipe corrected (script-registered Scheduled Task or Remediations — no native payload).
- **Sentinel spec** — `[CORRECTED 2026-07-30]` banner above the refuted paragraph (original text preserved as historical record).
- **`docs/superpowers/research/2026-07-30-endpoint-page-competitive-fact-check.md`** (new) — complete claim-by-claim verdicts with every source URL, incl. verification that all 7 ManageEngine Endpoint Central capability claims are accurate.
- **Number drift** — "1,200+ payloads" → "3,900+" everywhere (measured first-hand: `getAllPayloads()` = 3,962 across 25 categories); "1,184+ Malicious Skill IOCs" stat tile (ClawHavoc campaign figure, not a shipped capability) replaced with verified "18 MCP Clients Covered". The 1,184 figure remains only in `docs/openclaw-security.md` where it is correctly framed as campaign reporting.
- **README/docs indexes** — add missing `g0 protect` and `g0 sentinel` command rows; link `protect.md`, `hooks.md`, and the MDM solution brief.

## Verification

- Payload count measured by running `getAllPayloads()` (3,962 / 25 categories)
- MCP client count from `src/mcp/well-known-paths.ts` (18 entries)
- `rg` sweep confirms no stale `1,200+` / `1,184+` capability claims remain outside the campaign-reporting context

🤖 Generated with [Claude Code](https://claude.com/claude-code)